### PR TITLE
Cache implicits in qsu tests to improve compile times

### DIFF
--- a/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
@@ -20,7 +20,6 @@ import slamdata.Predef.{Map => SMap, _}
 
 import quasar.{IdStatus, Qspec, Type}, IdStatus.{ExcludeId, IncludeId}
 import quasar.common.JoinType
-import quasar.contrib.iota._
 import quasar.contrib.pathy.AFile
 import quasar.ejson.{EJson, Fixed}
 import quasar.ejson.implicits._
@@ -35,11 +34,10 @@ import quasar.qscript.{
   RightSide
 }
 import quasar.qscript.MapFuncsCore.RecIntLit
-import quasar.qsu.mra.ProvImpl
+import quasar.qsu.mra.{Dim, ProvImpl, Uop}
 
 import cats.instances.list._
 
-import matryoshka._
 import matryoshka.data.Fix
 
 import org.specs2.matcher.{Expectable, Matcher, MatchResult}
@@ -55,12 +53,13 @@ import scalaz.std.option._
 import scalaz.std.map._
 import scalaz.std.tuple._
 
-import shims.{eqToScalaz, orderToCats, orderToScalaz, showToCats, showToScalaz}
+import shims.{orderToCats, showToCats}
 
 object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
 
   import ApplyProvenance.{AuthenticatedQSU, computeFuncDims}
   import QScriptUniform.{DTrans, Rotation}
+  import ProvImpl.Vecs
 
   type F[A] = PlannerError \/ A
   type QSU[A] = QScriptUniform[A]
@@ -74,6 +73,13 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
   val qprov = ProvImpl[Fix[EJson], IdAccess, IdType]
   val B = Bucketing(qprov)
   val app = ApplyProvenance[Fix, F](qprov, _: QSUGraph)
+
+  // These instances are an optimization to reduce compile time by almost two orders of magnitude
+  implicit val provScalazEqual: scalaz.Equal[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]] =
+    scalaz.Equal.equal(cats.Eq[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]].eqv)
+
+  implicit val provScalazShow: scalaz.Show[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]] =
+    scalaz.Show.shows(cats.Show[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]].show)
 
   import qprov.syntax._
 

--- a/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
@@ -20,6 +20,7 @@ import slamdata.Predef.{Map => SMap, _}
 
 import quasar.{IdStatus, Qspec, Type}, IdStatus.{ExcludeId, IncludeId}
 import quasar.common.JoinType
+import quasar.contrib.iota._
 import quasar.contrib.pathy.AFile
 import quasar.ejson.{EJson, Fixed}
 import quasar.ejson.implicits._
@@ -75,11 +76,11 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
   val app = ApplyProvenance[Fix, F](qprov, _: QSUGraph)
 
   // These instances are an optimization to reduce compile time by almost two orders of magnitude
-  implicit val provScalazEqual: scalaz.Equal[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]] =
+  implicit def provScalazEqual: scalaz.Equal[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]] =
     scalaz.Equal.equal(cats.Eq[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]].eqv)
 
-  implicit val provScalazShow: scalaz.Show[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]] =
-    scalaz.Show.shows(cats.Show[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]].show)
+  implicit def provScalazShow: scalaz.Show[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]] =
+    scalaz.Show.shows(Uop.show[Vecs[Dim[Fix[EJson], IdAccess, IdType]]].show)
 
   import qprov.syntax._
 

--- a/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
@@ -74,13 +74,13 @@ object MinimizeAutoJoinsSpec
   val qprov = ProvImpl[Fix[EJson], IdAccess, IdType]
 
   // These instances are an optimization to reduce compile time by an order of magnitude
-  implicit val provScalazEqual: scalaz.Equal[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]] =
+  implicit def provScalazEqual: scalaz.Equal[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]] =
     scalaz.Equal.equal(cats.Eq[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]].eqv)
 
-  implicit val provScalazShow: scalaz.Show[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]] =
-    scalaz.Show.shows(cats.Show[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]].show)
+  implicit def provScalazShow: scalaz.Show[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]] =
+    scalaz.Show.shows(Uop.show[Vecs[Dim[Fix[EJson], IdAccess, IdType]]].show)
 
-  implicit val qsuEqual: scalaz.Equal[Fix[QScriptUniform]] =
+  implicit def qsuEqual: scalaz.Equal[Fix[QScriptUniform]] =
     matryoshka.equalTEqual[Fix, QScriptUniform]
 
   implicit def recFreeMapEqual[A: scalaz.Equal]: scalaz.Equal[RecFreeMapA[A]] =

--- a/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
@@ -16,6 +16,7 @@
 
 package quasar.qsu
 
+
 import slamdata.Predef._
 import quasar.{Qspec, TreeMatchers, Type}
 import quasar.IdStatus.{ExcludeId, IdOnly, IncludeId}
@@ -30,16 +31,15 @@ import quasar.qscript.{
   MapFuncsCore,
   OnUndefined,
   PlannerError,
+  RecFreeS,
   ReduceFuncs,
   ReduceIndex,
   RightSide,
   SrcHole
 }
-import quasar.qsu.mra.ProvImpl
+import quasar.qsu.mra.{Dim, ProvImpl, Uop}
 
-import matryoshka._
 import matryoshka.data.Fix
-import matryoshka.data.free._
 
 import org.specs2.matcher.{Matcher, MatchersImplicits}
 
@@ -53,7 +53,7 @@ import scalaz.syntax.equal._
 //import scalaz.syntax.show._
 import scalaz.syntax.tag._
 
-import shims.{eqToScalaz, monoidToCats, orderToCats, orderToScalaz, showToCats, showToScalaz}
+import shims.{monoidToCats, orderToCats, showToCats}
 
 object MinimizeAutoJoinsSpec
     extends Qspec
@@ -64,6 +64,7 @@ object MinimizeAutoJoinsSpec
   import QSUGraph.Extractors._
   import ApplyProvenance.AuthenticatedQSU
   import QScriptUniform.{DTrans, Retain, Rotation}
+  import ProvImpl.Vecs
 
   type F[A] = EitherT[StateT[Need, Long, ?], PlannerError, A]
 
@@ -71,6 +72,22 @@ object MinimizeAutoJoinsSpec
   val func = construction.Func[Fix]
   val recFunc = construction.RecFunc[Fix]
   val qprov = ProvImpl[Fix[EJson], IdAccess, IdType]
+
+  // These instances are an optimization to reduce compile time by an order of magnitude
+  implicit val provScalazEqual: scalaz.Equal[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]] =
+    scalaz.Equal.equal(cats.Eq[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]].eqv)
+
+  implicit val provScalazShow: scalaz.Show[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]] =
+    scalaz.Show.shows(cats.Show[Uop[Vecs[Dim[Fix[EJson], IdAccess, IdType]]]].show)
+
+  implicit val qsuEqual: scalaz.Equal[Fix[QScriptUniform]] =
+    matryoshka.equalTEqual[Fix, QScriptUniform]
+
+  implicit def recFreeMapEqual[A: scalaz.Equal]: scalaz.Equal[RecFreeMapA[A]] =
+    RecFreeS.equal[MapFunc, A]
+
+  implicit def freeMapEqual[A: scalaz.Equal]: scalaz.Equal[FreeMapA[A]] =
+    matryoshka.data.free.freeEqual[MapFunc].apply(scalaz.Equal[A])
 
   type J = Fix[EJson]
   val J = Fixed[Fix[EJson]]

--- a/sql/src/test/scala/quasar/sql/SqlParserSpec.scala
+++ b/sql/src/test/scala/quasar/sql/SqlParserSpec.scala
@@ -739,13 +739,13 @@ class SQLParserSpec extends quasar.Qspec {
         p => if (p ≠ node) println(pprint(p) + "\n" + (node.render diff p.render).show))
 
       parsed must beRightDisjOrDiff(node)
-    }.set(minTestsOk = 1000) // one cannot test a parser too much
+    }
 
     "round-trip module" >> prop { module: List[Statement[Fix[Sql]]] =>
       val back = fixParser.parseModule(module.pprint)
 
       back must beRightDisjOrDiff(module)
-    }
+    }.set(maxSize = 10)
 
     "pprint an import statement should escpae backticks" >> {
       val `import` = Import[Fix[Sql]](currentDir </> dir("di") </> dir("k`~ireW.5u1+fOh") </> dir("j"))


### PR DESCRIPTION
Reduces qsu/test compile times by ~90s locally.