### PR TITLE
Upgrade to Azure SDK v12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -282,9 +282,9 @@ lazy val impl = project
       "io.netty"       % "netty-all"                 % nettyVersion,
       "org.mapdb"      % "mapdb"                     % mapdbVersion,
       "eu.timepit"     %% "refined-scalacheck"       % refinedVersion % Test,
-      // woodstox is added here as a quick and dirty way to get azure working
-      // see ch3385 for details
-      "com.fasterxml.woodstox" % "woodstox-core" % "6.0.2",
-
+      // The azure-core-http-netty dep is added here as a quick and dirty way to get azure working.
+      // Azure relies on service provider mechanism to load an implementation of its HttpClientProvider.
+      // If it is not added then no HttpClientProvider implementation can be found.
+      "com.azure" % "azure-core-http-netty" % "1.5.1",
       "org.typelevel" %% "kittens" % kittensVersion % Test))
   .evictToLocal("FS2_JOB_PATH", "core")

--- a/build.sbt
+++ b/build.sbt
@@ -284,7 +284,10 @@ lazy val impl = project
       "eu.timepit"     %% "refined-scalacheck"       % refinedVersion % Test,
       // The azure-core-http-netty dep is added here as a quick and dirty way to get azure working.
       // Azure relies on service provider mechanism to load an implementation of its HttpClientProvider.
-      // If it is not added then no HttpClientProvider implementation can be found.
+      // The implementation class is available in the azure plugins, but
+      // somehow the wrong class loader is trying to load the implementation and
+      // if it is not added here then no HttpClientProvider implementation can be found.
+      // See ch11286.
       "com.azure" % "azure-core-http-netty" % "1.5.1",
       "org.typelevel" %% "kittens" % kittensVersion % Test))
   .evictToLocal("FS2_JOB_PATH", "core")

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -25,7 +25,7 @@ object Versions {
   val slf4sVersion        = "1.7.25"
   val atomixVersion       = "3.0.11" // This is freezed, because atomix changed discovery service somehow
   val mapdbVersion        = "3.0.8"
-  val nettyVersion        = "4.1.47.Final"
+  val nettyVersion        = "4.1.49.Final"
   val skolemsVersion      = "0.2.1"
   val kittensVersion      = "2.0.0"
 }


### PR DESCRIPTION
Add azure-core-http-netty dependency as workaround. If this dependency is not added then Azure cannot find any implementation of HttpClientProvider.

Part of ch11156

Marked as `breaking` because this PR is needed to get the Azure dependent datasources and destinations relying on https://github.com/precog/async-blobstore/pull/98 (upgrade to Azure SDK v12) working, so those plugins. At the same time plugin versions that are relying on Azure SDK v10 won't work anymore with this PR. 

So quasar and all the Azure dependent plugins need to support the same Azure SDK version.