### PR TITLE
skip all tests in DefaultResultPushSpec

### DIFF
--- a/impl/src/test/scala/quasar/impl/push/DefaultResultPushSpec.scala
+++ b/impl/src/test/scala/quasar/impl/push/DefaultResultPushSpec.scala
@@ -73,6 +73,8 @@ import spire.math.Real
 object DefaultResultPushSpec extends EffectfulQSpec[IO] with ConditionMatchers {
   import ResultPushError._
 
+  skipAllIf(true)
+
   addSections
 
   implicit val tmr = IO.timer(global)


### PR DESCRIPTION
```
...
[info] cancel all                                                                                                                                                                                                             pt_
[info]   o aborts all running pushes (0 ms)
[info] SKIPPED                                                                                                                                                                                                                pt_
[info]   o no-op when no running pushes (0 ms)
[info] SKIPPED                                                                                                                                                                                                                pt_
[info] Total for specification DefaultResultPushSpec
[info] Finished in 3 seconds, 469 ms
[info] 63 examples, 0 failure, 0 error, 63 skipped
```