### PR TITLE
no need in sanitation when applying patch

### DIFF
--- a/impl/src/main/scala/quasar/impl/datasources/DefaultDatasources.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DefaultDatasources.scala
@@ -120,7 +120,7 @@ private[impl] final class DefaultDatasources[
 
   def reconfigureDatasource(datasourceId: I, patch: C)
       : F[Condition[DatasourceError[I, C]]] =
-    datasourceRef(datasourceId) flatMap {
+    lookupRef[DatasourceError[I, C]](datasourceId) flatMap {
       case -\/(err) => Condition.abnormal(err: DatasourceError[I, C]).point[F]
       case \/-(ref) => modules.reconfigureRef(ref, patch) match {
         case Left(err) => Condition.abnormal(err: DatasourceError[I, C]).point[F]
@@ -130,7 +130,7 @@ private[impl] final class DefaultDatasources[
 
   def renameDatasource(datasourceId: I, name: DatasourceName)
       : F[Condition[DatasourceError[I, C]]] =
-    datasourceRef(datasourceId) flatMap {
+    lookupRef[DatasourceError[I, C]](datasourceId) flatMap {
       case -\/(err) => Condition.abnormal(err: DatasourceError[I, C]).point[F]
       case \/-(ref) => replaceDatasource(datasourceId, ref.copy(name = name))
     }


### PR DESCRIPTION
Released as `177.0.1-ed3252c`

`datasourceRef` has `"<REDACTED>"` in credentials.