### PR TITLE
Updated cached getter after datasource replace

### DIFF
--- a/impl/src/main/scala/quasar/impl/datasources/DefaultDatasources.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DefaultDatasources.scala
@@ -97,7 +97,7 @@ private[impl] final class DefaultDatasources[
         addRef[DatasourceError[I, C]](i, ref)
 
     throughSemaphore(i) {
-      getter(i) flatMap {
+      getter(i).flatMap {
         // We're replacing, emit abnormal condition if there was no ref
         case Empty =>
           notFound.point[F]
@@ -114,7 +114,7 @@ private[impl] final class DefaultDatasources[
 
         case Present(value) =>
           doReplace(value)
-      }
+      } <* getter(i)
     }
   }
 


### PR DESCRIPTION
Due to how cached getter updates when read, it had a stale value post-replace. Accessing the getter after the replace causes it to update to the current state of the system.