### PR TITLE
Added stream size expectation utility

### DIFF
--- a/foundation/src/main/scala/quasar/contrib/fs2/expect.scala
+++ b/foundation/src/main/scala/quasar/contrib/fs2/expect.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.contrib.fs2
+
+import slamdata.Predef._
+
+import fs2.{Pipe, Pull, Stream}
+
+object expect {
+
+  def size[F[_], A](count: Long)(orElse: Long => Stream[F, A]): Pipe[F, A, A] = { in =>
+    def loop(in: Stream[F, A], acc: Long): Pull[F, A, Unit] =
+      in.pull.uncons flatMap {
+        case Some((chunk, tail)) =>
+          Pull.output(chunk) >> loop(tail, acc + chunk.size)
+
+        case None =>
+          if (acc != count)
+            orElse(acc).pull.echo
+          else
+            Pull.done
+      }
+
+    loop(in, 0L).stream
+  }
+}

--- a/foundation/src/test/scala/quasar/contrib/fs2/ExpectSpec.scala
+++ b/foundation/src/test/scala/quasar/contrib/fs2/ExpectSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.contrib.fs2
+
+import slamdata.Predef._
+
+import fs2.Stream
+
+import org.specs2.mutable.Specification
+
+class ExpectSpec extends Specification {
+
+  "stream size expectation" should {
+    "accept an empty stream" in {
+      Stream.empty.through(expect.size(0L)(Stream.emit(_))).compile.toList must beEmpty
+    }
+
+    "reject an empty stream when expecting more" in {
+      Stream.empty.through(expect.size(1L)(Stream.emit(_))).compile.toList mustEqual List(0L)
+    }
+
+    "accept a stream of five things across two chunks" in {
+      val s = Stream(1, 2) ++ Stream(3, 4, 5)
+      s.through(expect.size(5L)(size => Stream.emit(size.toInt))).compile.toList mustEqual List(1, 2, 3, 4, 5)
+    }
+
+    "reject a stream of five things across two chunks when expecting more" in {
+      val s = Stream(1, 2) ++ Stream(3, 4, 5)
+      s.through(expect.size(7L)(size => Stream.emit(size.toInt))).compile.toList mustEqual List(1, 2, 3, 4, 5, 5)
+    }
+
+    "reject a stream of five things across two chunks when expecting less" in {
+      val s = Stream(1, 2) ++ Stream(3, 4, 5)
+      s.through(expect.size(4L)(size => Stream.emit(size.toInt))).compile.toList mustEqual List(1, 2, 3, 4, 5, 5)
+    }
+  }
+}


### PR DESCRIPTION
This is a tiny little utility which gives us the ability to assert that a stream should be a particular length and then recover (or produce an error) if it isn't, either because it's too small or too large. This can be used in the S3 connector, for example, to read the `Content-Range` header in the response and then assert that the `body` has the appropriate number of bytes. Or in a more advanced implementation, if the `body` does *not* have the appropriate number of bytes, rather than raising an error, it could simply make a new request to S3 using the `Range` header parameter, resuming exactly where the stream left off.