### PR TITLE
Destination type/pair

### DIFF
--- a/api/src/main/scala/quasar/api/Labeled.scala
+++ b/api/src/main/scala/quasar/api/Labeled.scala
@@ -17,9 +17,10 @@
 package quasar.api
 
 import cats.{Applicative, Eq, Eval, Order, Show, Traverse}
+import cats.data._
 import cats.implicits._
 
-import scala.{Predef, StringContext}, Predef._
+import scala._, Predef._
 
 import java.lang.String
 
@@ -34,7 +35,6 @@ private[api] trait LowPriorityImplicits {
 }
 
 object Labeled extends LowPriorityImplicits {
-
   implicit def label[A]: Label[Labeled[A]] =
     Label.label(_.label)
 

--- a/api/src/main/scala/quasar/api/Labeled.scala
+++ b/api/src/main/scala/quasar/api/Labeled.scala
@@ -17,10 +17,9 @@
 package quasar.api
 
 import cats.{Applicative, Eq, Eval, Order, Show, Traverse}
-import cats.data._
 import cats.implicits._
 
-import scala._, Predef._
+import scala.{Predef, StringContext}, Predef._
 
 import java.lang.String
 
@@ -35,6 +34,7 @@ private[api] trait LowPriorityImplicits {
 }
 
 object Labeled extends LowPriorityImplicits {
+
   implicit def label[A]: Label[Labeled[A]] =
     Label.label(_.label)
 

--- a/api/src/main/scala/quasar/api/push/param/ParamType.scala
+++ b/api/src/main/scala/quasar/api/push/param/ParamType.scala
@@ -24,7 +24,7 @@ import java.lang.String
 
 import scala.{Boolean => SBoolean, Int, Nothing, Option, Product, Serializable, Unit}
 
-sealed trait ParamType[F[_], A] extends Product with Serializable
+trait ParamType[F[_], A] extends Product with Serializable
 
 object ParamType {
   final case class Boolean[F[_]](value: F[Unit])

--- a/api/src/main/scala/quasar/api/push/param/package.scala
+++ b/api/src/main/scala/quasar/api/push/param/package.scala
@@ -36,6 +36,8 @@ package object param {
 
     def enum[A](x: (String, A), xs: (String, A)*): Formal[A] =
       ParamType.Enum[Id, A](NonEmptyMap.of(x, xs: _*))
+
+    final case class Pair[A, B](fst: Formal[A], snd: Formal[B]) extends Formal[(A, B)]
   }
 
   object Actual {
@@ -47,5 +49,7 @@ package object param {
 
     def enumSelect(s: String): Actual[String] =
       ParamType.EnumSelect(Const(s))
+
+    final case class Pair[A, B](fst: Actual[A], snd: Actual[B]) extends Actual[(A, B)]
   }
 }

--- a/impl/src/main/scala/quasar/impl/push/DefaultResultPush.scala
+++ b/impl/src/main/scala/quasar/impl/push/DefaultResultPush.scala
@@ -476,13 +476,9 @@ private[impl] final class DefaultResultPush[
           def mkConstructorArg(formal: ∃[Formal], actual: ∃[Actual]): Either[ParamError, e.A] =
             (formal.value: Formal[A] forSome { type A }, actual) match {
               case (Formal.Pair(formalA, formalB), ∃(Actual.Pair(actualA, actualB))) =>
-                val exA: ∃[Formal] = ∃(formalA)
-                val exB: ∃[Formal] = ∃(formalB)
-                val exAA: ∃[Actual] = ∃(actualA)
-                val exBA: ∃[Actual] = ∃(actualB)
                 for {
-                  a <- mkConstructorArg(∃(formalA), ∃(actualA))
-                  b <- mkConstructorArg(∃(formalB), ∃(actualB))
+                  a <- mkConstructorArg(formalA, actualA)
+                  b <- mkConstructorArg(formalB, actualB)
                 } yield ((a, b)).asInstanceOf[e.A]
 
               case (Boolean(_), ∃(Boolean(Const(b)))) =>


### PR DESCRIPTION
This introduces `Formal.Pair` and `Actual.Pair`, works _almost_ like it should, but `CoercedType` has `Maybe[Labeled[Exists[Formal]]]` which means that we can have only one label for paired arguments. 

It's OK for now, since we don't use argument labels at frontend yet, but it seems that `Label` and `Labeled` should be generalized a bit. 

🛑 Until all reviews are OK 