### PR TITLE
Add SeekFailed error

### DIFF
--- a/connector/src/main/scala/quasar/connector/ResourceError.scala
+++ b/connector/src/main/scala/quasar/connector/ResourceError.scala
@@ -69,8 +69,8 @@ object ResourceError extends ResourceErrorInstances {
     val cause = None
   }
 
-  final case class SeekFailed(path: ResourcePath) extends ResourceError {
-    val detail = None
+  final case class SeekFailed(path: ResourcePath, reason: String) extends ResourceError {
+    val detail = Some(reason)
     val cause = None
   }
 
@@ -118,10 +118,10 @@ object ResourceError extends ResourceErrorInstances {
       case SeekUnsupported(p) => p
     } (SeekUnsupported(_))
 
-  val seekFailed: Prism[ResourceError, ResourcePath] =
-    Prism.partial[ResourceError, ResourcePath] {
-      case SeekFailed(p) => p
-    } (SeekFailed(_))
+  val seekFailed: Prism[ResourceError, (ResourcePath, String)] =
+    Prism.partial[ResourceError, (ResourcePath, String)] {
+      case SeekFailed(p, r) => (p, r)
+    } (SeekFailed.tupled)
 
   val tooManyResources: Prism[ResourceError, (NonEmptyList[ResourcePath], String)] =
     Prism.partial[ResourceError, (NonEmptyList[ResourcePath], String)] {
@@ -180,8 +180,8 @@ sealed abstract class ResourceErrorInstances {
       case ResourceError.SeekUnsupported(p) =>
         s"SeekUnsupported(${p.shows})"
 
-      case ResourceError.SeekFailed(p) =>
-        s"SeekFailed(${p.shows})"
+      case ResourceError.SeekFailed(p, r) =>
+        s"SeekFailed(path: ${p.shows}, detail: $r)"
 
       case ResourceError.TooManyResources(ps, r) =>
         s"TooManyResources(${ps.toList.shows}, $r)"

--- a/connector/src/main/scala/quasar/connector/ResourceError.scala
+++ b/connector/src/main/scala/quasar/connector/ResourceError.scala
@@ -151,6 +151,7 @@ sealed abstract class ResourceErrorInstances {
       ResourceError.notAResource.getOption(e),
       ResourceError.pathNotFound.getOption(e),
       ResourceError.seekUnsupported.getOption(e),
+      ResourceError.seekFailed.getOption(e),
       ResourceError.tooManyResources.getOption(e)))
   }
 

--- a/connector/src/main/scala/quasar/connector/ResourceError.scala
+++ b/connector/src/main/scala/quasar/connector/ResourceError.scala
@@ -69,6 +69,11 @@ object ResourceError extends ResourceErrorInstances {
     val cause = None
   }
 
+  final case class SeekFailed(path: ResourcePath) extends ResourceError {
+    val detail = None
+    val cause = None
+  }
+
   final case class TooManyResources(paths: NonEmptyList[ResourcePath], reason: String)
       extends ResourceError {
     val path = paths.head
@@ -112,6 +117,11 @@ object ResourceError extends ResourceErrorInstances {
     Prism.partial[ResourceError, ResourcePath] {
       case SeekUnsupported(p) => p
     } (SeekUnsupported(_))
+
+  val seekFailed: Prism[ResourceError, ResourcePath] =
+    Prism.partial[ResourceError, ResourcePath] {
+      case SeekFailed(p) => p
+    } (SeekFailed(_))
 
   val tooManyResources: Prism[ResourceError, (NonEmptyList[ResourcePath], String)] =
     Prism.partial[ResourceError, (NonEmptyList[ResourcePath], String)] {
@@ -168,6 +178,9 @@ sealed abstract class ResourceErrorInstances {
 
       case ResourceError.SeekUnsupported(p) =>
         s"SeekUnsupported(${p.shows})"
+
+      case ResourceError.SeekFailed(p) =>
+        s"SeekFailed(${p.shows})"
 
       case ResourceError.TooManyResources(ps, r) =>
         s"TooManyResources(${ps.toList.shows}, $r)"


### PR DESCRIPTION
This is the first PR implementing ch10728.

This is an error raised when Quasar asked for a seek, but we could not perform it. Before the introduction of CDC, we could handle pushdown evaluation errors by simply returning the unevaluated `ScalarStages` and letting Quasar handle evaluation. However, this is no longer appropriate when we're asked to seek and fail.

`version: breaking` because it needs handling in sdbe.