### PR TITLE
Replace all usage of scalaz.Need with cats.Eval

### DIFF
--- a/core/src/main/scala/quasar/compile/Compiler.scala
+++ b/core/src/main/scala/quasar/compile/Compiler.scala
@@ -830,7 +830,7 @@ object Compiler {
     val KS = MonadState_[State[KeyState, ?], KeyState]
 
     def makeKey(tree: T, flp: ZFree[LP, Unit]): T =
-      flp.cataM(interpretM[Eval, LP, Unit, T](_ => Eval.now(tree), fa => Eval.later(fa.embed))).value
+      flp.cataM(interpretM[Eval, LP, Unit, T](_ => Eval.now(tree), fa => Eval.always(fa.embed))).value
 
     // Step 1: annotate nodes containing the keys.
     val ann: State[KeyState, Cofree[LP, Boolean]] = tree.transAnaM {

--- a/core/src/main/scala/quasar/compile/Compiler.scala
+++ b/core/src/main/scala/quasar/compile/Compiler.scala
@@ -40,6 +40,7 @@ import quasar.sql._
 import quasar.std.StdLib, StdLib._
 import quasar.time.TemporalPart
 
+import cats.Eval
 import cats.data.{EitherT, State, StateT}
 
 import matryoshka._
@@ -49,7 +50,7 @@ import matryoshka.patterns._
 
 import pathy.Path._
 
-import scalaz.{\/, -\/, \/-, Cofree, Equal, Functor, Free => ZFree, Monad, Need, Scalaz, Show}, Scalaz._
+import scalaz.{\/, -\/, \/-, Cofree, Equal, Functor, Free => ZFree, Monad, Scalaz, Show}, Scalaz._
 
 import shapeless.{Annotations => _, Data => _, :: => _, _}
 
@@ -789,7 +790,7 @@ object Compiler {
      TC: Corecursive.Aux[T, LP],
      S: Show[T])
      : SemanticError \/ T =
-    apply[StateT[EitherT[cats.Eval, SemanticError, ?], CompilerState[T], ?], T]
+    apply[StateT[EitherT[Eval, SemanticError, ?], CompilerState[T], ?], T]
       .compile(tree)
       .runA(CompilerState(Nil, Context(Nil, Nil), 0))
       .value.value.disjunction
@@ -829,7 +830,7 @@ object Compiler {
     val KS = MonadState_[State[KeyState, ?], KeyState]
 
     def makeKey(tree: T, flp: ZFree[LP, Unit]): T =
-      flp.cataM(interpretM[Need, LP, Unit, T](_ => Need(tree), fa => Need(fa.embed))).value
+      flp.cataM(interpretM[Eval, LP, Unit, T](_ => Eval.now(tree), fa => Eval.later(fa.embed))).value
 
     // Step 1: annotate nodes containing the keys.
     val ann: State[KeyState, Cofree[LP, Boolean]] = tree.transAnaM {

--- a/foundation/src/main/scala/quasar/contrib/iota/LazyEqualKMaterializer.scala
+++ b/foundation/src/main/scala/quasar/contrib/iota/LazyEqualKMaterializer.scala
@@ -20,6 +20,8 @@ import slamdata.Predef._
 
 import quasar.contrib.matryoshka.LazyEqual
 
+import cats.Eval
+
 import iotaz.TListK.:::
 import iotaz.{CopK, TListK, TNilK}
 
@@ -43,7 +45,7 @@ object LazyEqualKMaterializer {
         override def apply[A](eql: LazyEqual[A]): LazyEqual[CopK[F ::: TNilK, A]] = {
           LazyEqual lazyEqual {
             case (I(left), I(right)) => F(eql).equal(left, right)
-            case _ => Need(false)
+            case _ => Eval.now(false)
           }
         }
       })

--- a/foundation/src/main/scala/quasar/contrib/matryoshka/LazyEqual.scala
+++ b/foundation/src/main/scala/quasar/contrib/matryoshka/LazyEqual.scala
@@ -36,5 +36,5 @@ object LazyEqual {
     }
 
   def recursive[T, F[_]: Functor](implicit T: Recursive.Aux[T, F], F: Delay[LazyEqual, F]): LazyEqual[T] =
-    lazyEqual((x, y) => Eval.later(F(recursive[T, F])).flatMap(_.equal(T.project(x), T.project(y))))
+    lazyEqual((x, y) => Eval.always(F(recursive[T, F])).flatMap(_.equal(T.project(x), T.project(y))))
 }

--- a/foundation/src/main/scala/quasar/contrib/matryoshka/LazyEqual.scala
+++ b/foundation/src/main/scala/quasar/contrib/matryoshka/LazyEqual.scala
@@ -20,21 +20,21 @@ import scala.Boolean
 
 import matryoshka.{Delay, Recursive}
 
-import scalaz.{Functor, Need}
-import scalaz.syntax.bind._
+import cats.Eval
+import scalaz.Functor
 
 trait LazyEqual[A] {
-  def equal(x: A, y: A): Need[Boolean]
+  def equal(x: A, y: A): Eval[Boolean]
 }
 
 object LazyEqual {
   def apply[A](implicit ev: LazyEqual[A]): LazyEqual[A] = ev
 
-  def lazyEqual[A](f: (A, A) => Need[Boolean]): LazyEqual[A] =
+  def lazyEqual[A](f: (A, A) => Eval[Boolean]): LazyEqual[A] =
     new LazyEqual[A] {
       def equal(x: A, y: A) = f(x, y)
     }
 
   def recursive[T, F[_]: Functor](implicit T: Recursive.Aux[T, F], F: Delay[LazyEqual, F]): LazyEqual[T] =
-    lazyEqual((x, y) => Need(F(recursive[T, F])).flatMap(_.equal(T.project(x), T.project(y))))
+    lazyEqual((x, y) => Eval.later(F(recursive[T, F])).flatMap(_.equal(T.project(x), T.project(y))))
 }

--- a/qscript/src/main/scala/quasar/qscript/MapFuncCore.scala
+++ b/qscript/src/main/scala/quasar/qscript/MapFuncCore.scala
@@ -29,6 +29,7 @@ import quasar.contrib.iota._
 import quasar.fp.ski._
 import quasar.time.TemporalPart
 
+import cats.Eval
 import matryoshka._
 import matryoshka.data._
 import matryoshka.implicits._
@@ -476,13 +477,13 @@ object MapFuncCore {
         // nullary
         case (Constant(v1), Constant(v2)) =>
           // FIXME: Ensure we’re using _structural_ equality here.
-          Need(v1 ≟ v2)
-        case (JoinSideName(n1), JoinSideName(n2)) => Need(n1 ≟ n2)
-        case (Undefined(), Undefined()) => Need(true)
-        case (Now(), Now()) => Need(true)
-        case (NowTime(), NowTime()) => Need(true)
-        case (NowDate(), NowDate()) => Need(true)
-        case (CurrentTimeZone(), CurrentTimeZone()) => Need(true)
+          Eval.later(v1 ≟ v2)
+        case (JoinSideName(n1), JoinSideName(n2)) => Eval.later(n1 ≟ n2)
+        case (Undefined(), Undefined()) => Eval.now(true)
+        case (Now(), Now()) => Eval.now(true)
+        case (NowTime(), NowTime()) => Eval.now(true)
+        case (NowDate(), NowDate()) => Eval.now(true)
+        case (CurrentTimeZone(), CurrentTimeZone()) => Eval.now(true)
         // unary
         case (ExtractCentury(a1), ExtractCentury(a2)) => in.equal(a1, a2)
         case (ExtractDayOfMonth(a1), ExtractDayOfMonth(a2)) => in.equal(a1, a2)
@@ -513,7 +514,7 @@ object MapFuncCore {
         case (LocalDate(a1), LocalDate(b1)) => in.equal(a1, b1)
         case (Interval(a1), Interval(b1)) => in.equal(a1, b1)
         case (StartOfDay(a1), StartOfDay(b1)) => in.equal(a1, b1)
-        case (TemporalTrunc(a1, a2), TemporalTrunc(b1, b2)) => Need(a1 ≟ b1) && in.equal(a2, b2)
+        case (TemporalTrunc(a1, a2), TemporalTrunc(b1, b2)) => Eval.later(a1 ≟ b1) && in.equal(a2, b2)
         case (TimeOfDay(a1), TimeOfDay(b1)) => in.equal(a1, b1)
         case (ToTimestamp(a1), ToTimestamp(b1)) => in.equal(a1, b1)
         case (TypeOf(a1), TypeOf(b1)) => in.equal(a1, b1)
@@ -570,9 +571,9 @@ object MapFuncCore {
         case (Search(a1, a2, a3), Search(b1, b2, b3)) => in.equal(a1, b1) && in.equal(a2, b2) && in.equal(a3, b3)
         case (Like(a1, a2, a3), Like(b1, b2, b3)) => in.equal(a1, b1) && in.equal(a2, b2) && in.equal(a3, b3)
         case (Substring(a1, a2, a3), Substring(b1, b2, b3)) => in.equal(a1, b1) && in.equal(a2, b2) && in.equal(a3, b3)
-        case (Guard(a1, atpe, a2, a3), Guard(b1, btpe, b2, b3)) => Need(atpe ≟ btpe) && in.equal(a1, b1) && in.equal(a2, b2) && in.equal(a3, b3)
+        case (Guard(a1, atpe, a2, a3), Guard(b1, btpe, b2, b3)) => Eval.later(atpe ≟ btpe) && in.equal(a1, b1) && in.equal(a2, b2) && in.equal(a3, b3)
 
-        case (_, _) => Need(false)
+        case (_, _) => Eval.now(false)
       }
     }
 

--- a/qscript/src/main/scala/quasar/qscript/MapFuncCore.scala
+++ b/qscript/src/main/scala/quasar/qscript/MapFuncCore.scala
@@ -477,8 +477,8 @@ object MapFuncCore {
         // nullary
         case (Constant(v1), Constant(v2)) =>
           // FIXME: Ensure we’re using _structural_ equality here.
-          Eval.later(v1 ≟ v2)
-        case (JoinSideName(n1), JoinSideName(n2)) => Eval.later(n1 ≟ n2)
+          Eval.always(v1 ≟ v2)
+        case (JoinSideName(n1), JoinSideName(n2)) => Eval.always(n1 ≟ n2)
         case (Undefined(), Undefined()) => Eval.now(true)
         case (Now(), Now()) => Eval.now(true)
         case (NowTime(), NowTime()) => Eval.now(true)
@@ -514,7 +514,7 @@ object MapFuncCore {
         case (LocalDate(a1), LocalDate(b1)) => in.equal(a1, b1)
         case (Interval(a1), Interval(b1)) => in.equal(a1, b1)
         case (StartOfDay(a1), StartOfDay(b1)) => in.equal(a1, b1)
-        case (TemporalTrunc(a1, a2), TemporalTrunc(b1, b2)) => Eval.later(a1 ≟ b1) && in.equal(a2, b2)
+        case (TemporalTrunc(a1, a2), TemporalTrunc(b1, b2)) => Eval.always(a1 ≟ b1) && in.equal(a2, b2)
         case (TimeOfDay(a1), TimeOfDay(b1)) => in.equal(a1, b1)
         case (ToTimestamp(a1), ToTimestamp(b1)) => in.equal(a1, b1)
         case (TypeOf(a1), TypeOf(b1)) => in.equal(a1, b1)
@@ -571,7 +571,7 @@ object MapFuncCore {
         case (Search(a1, a2, a3), Search(b1, b2, b3)) => in.equal(a1, b1) && in.equal(a2, b2) && in.equal(a3, b3)
         case (Like(a1, a2, a3), Like(b1, b2, b3)) => in.equal(a1, b1) && in.equal(a2, b2) && in.equal(a3, b3)
         case (Substring(a1, a2, a3), Substring(b1, b2, b3)) => in.equal(a1, b1) && in.equal(a2, b2) && in.equal(a3, b3)
-        case (Guard(a1, atpe, a2, a3), Guard(b1, btpe, b2, b3)) => Eval.later(atpe ≟ btpe) && in.equal(a1, b1) && in.equal(a2, b2) && in.equal(a3, b3)
+        case (Guard(a1, atpe, a2, a3), Guard(b1, btpe, b2, b3)) => Eval.always(atpe ≟ btpe) && in.equal(a1, b1) && in.equal(a2, b2) && in.equal(a3, b3)
 
         case (_, _) => Eval.now(false)
       }

--- a/qscript/src/main/scala/quasar/qscript/MapFuncDerived.scala
+++ b/qscript/src/main/scala/quasar/qscript/MapFuncDerived.scala
@@ -22,6 +22,7 @@ import quasar._
 import quasar.contrib.matryoshka.LazyEqual
 import quasar.contrib.matryoshka.implicits._
 
+import cats.Eval
 import matryoshka._
 import monocle.macros.Lenses
 import scalaz._, Scalaz._
@@ -78,14 +79,14 @@ object MapFuncDerived {
         case (Floor(a1), Floor(a2)) => in.equal(a1, a2)
         case (Trunc(a1), Trunc(a2)) => in.equal(a1, a2)
         case (Round(a1), Round(a2)) => in.equal(a1, a2)
-        case (Typecheck(a1, typ1), Typecheck(a2, typ2)) => Need(typ1 === typ2) && in.equal(a1, a2)
+        case (Typecheck(a1, typ1), Typecheck(a2, typ2)) => Eval.later(typ1 === typ2) && in.equal(a1, a2)
 
         // binary
         case (FloorScale(a11, a12), FloorScale(a21, a22)) => in.equal(a11, a21) && in.equal(a12, a22)
         case (CeilScale(a11, a12), CeilScale(a21, a22))   => in.equal(a11, a21) && in.equal(a12, a22)
         case (RoundScale(a11, a12), RoundScale(a21, a22)) => in.equal(a11, a21) && in.equal(a12, a22)
 
-        case (_, _) => Need(false)
+        case (_, _) => Eval.now(false)
       }
     }
 

--- a/qscript/src/main/scala/quasar/qscript/MapFuncDerived.scala
+++ b/qscript/src/main/scala/quasar/qscript/MapFuncDerived.scala
@@ -79,7 +79,7 @@ object MapFuncDerived {
         case (Floor(a1), Floor(a2)) => in.equal(a1, a2)
         case (Trunc(a1), Trunc(a2)) => in.equal(a1, a2)
         case (Round(a1), Round(a2)) => in.equal(a1, a2)
-        case (Typecheck(a1, typ1), Typecheck(a2, typ2)) => Eval.later(typ1 === typ2) && in.equal(a1, a2)
+        case (Typecheck(a1, typ1), Typecheck(a2, typ2)) => Eval.always(typ1 === typ2) && in.equal(a1, a2)
 
         // binary
         case (FloorScale(a11, a12), FloorScale(a21, a22)) => in.equal(a11, a21) && in.equal(a12, a22)

--- a/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
+++ b/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
@@ -347,7 +347,7 @@ sealed abstract class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT: ShowT] exte
 
   private def computeFuncProvenance[A](fm: FreeMapA[A])(f: A => P): P = {
     val galgM: GAlgebraM[(FreeMapA[A], ?), Eval, MapFunc, P] =
-      mf => Eval.later(computeFuncProvenanceƒ[A](mf))
+      mf => Eval.always(computeFuncProvenanceƒ[A](mf))
 
     fm.paraM(ginterpretM(f.andThen(Eval.now(_)), galgM)).value
   }

--- a/qsu/src/test/scala/quasar/qsu/GraduateSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/GraduateSpec.scala
@@ -21,10 +21,11 @@ import quasar.Qspec
 import quasar.IdStatus.{ExcludeId, IncludeId}
 import quasar.api.resource.ResourcePath
 import quasar.common.{JoinType, SortDir}
+import quasar.contrib.cats.stateT._
+import quasar.contrib.iota._
 import quasar.contrib.pathy.AFile
 import quasar.ejson.{EJson, Fixed}
 import quasar.fp._
-import quasar.contrib.iota._
 import quasar.qscript.{
   construction,
   educatedToTotal,
@@ -44,6 +45,10 @@ import quasar.qscript.{
 import quasar.qscript.PlannerError.InternalError
 import quasar.qscript.MapFuncsCore.{IntLit, RecIntLit}
 import quasar.qsu.ApplyProvenance.AuthenticatedQSU
+
+import cats.Eval
+import cats.data.StateT
+
 import matryoshka.EqualT
 import matryoshka.data.Fix
 import Fix._
@@ -51,13 +56,15 @@ import org.specs2.matcher.{Expectable, MatchResult, Matcher}
 import pathy.Path
 import Path.{Sandboxed, file}
 
-import scalaz.{EitherT, Free, Need, StateT, \/, \/-, NonEmptyList => NEL}
+import scalaz.{EitherT, Free, \/, \/-, NonEmptyList => NEL}
 import scalaz.Scalaz._
+
+import shims.monadToScalaz
 
 object GraduateSpec extends Qspec with QSUTTypes[Fix] {
   import QScriptUniform.Rotation
 
-  type F[A] = EitherT[StateT[Need, Long, ?], PlannerError, A]
+  type F[A] = EitherT[StateT[Eval, Long, ?], PlannerError, A]
 
   type QSU[A] = QScriptUniform[A]
   type QSE[A] = QScriptEducated[A]
@@ -269,5 +276,5 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
     }
   }
 
-  def evaluate[A](fa: F[A]): PlannerError \/ A = fa.run.eval(0L).value
+  def evaluate[A](fa: F[A]): PlannerError \/ A = fa.run.runA(0L).value
 }

--- a/qsu/src/test/scala/quasar/qsu/RewriteGroupByArraysSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/RewriteGroupByArraysSpec.scala
@@ -18,18 +18,22 @@ package quasar.qsu
 
 import quasar.{ejson, IdStatus, Qspec}
 import quasar.common.data.Data
+import quasar.contrib.cats.stateT._
 import quasar.qscript.{construction, Hole, LeftSide, MapFuncsCore, MFC, RightSide, SrcHole}
 import slamdata.Predef._
 
+import cats.Eval
+import cats.data.StateT
 import matryoshka.data.Fix
 import pathy.Path, Path.Sandboxed
-import scalaz.{Need, StateT}
+
+import shims.monadToScalaz
 
 object RewriteGroupByArraysSpec extends Qspec with QSUTTypes[Fix] {
   import QSUGraph.Extractors._
   import IdStatus.ExcludeId
 
-  type F[A] = StateT[Need, Long, A]
+  type F[A] = StateT[Eval, Long, A]
 
   val qsu = QScriptUniform.DslT[Fix]
   val json = ejson.Fixed[Fix[ejson.EJson]]
@@ -282,5 +286,5 @@ object RewriteGroupByArraysSpec extends Qspec with QSUTTypes[Fix] {
     }
   }
 
-  def eval[A](fa: F[A]): A = fa.eval(0L).value
+  def eval[A](fa: F[A]): A = fa.runA(0L).value
 }


### PR DESCRIPTION
We need a trampolined monad to avoid SOE when compiling very large queries.

[ch11344]
[ch12247]