### PR TITLE
Additional stack-safety improvements

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,6 +1,5 @@
 -Xms512m
 -Xmx3g
--Xss4m
 -XX:+UseG1GC
 -XX:+UseStringDeduplication
 -XX:ParallelGCThreads=2

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,5 +1,6 @@
 -Xms512m
 -Xmx3g
+-Xss1m
 -XX:+UseG1GC
 -XX:+UseStringDeduplication
 -XX:ParallelGCThreads=2

--- a/impl/src/test/resources/test-queries/large-freemap-soe.sql
+++ b/impl/src/test/resources/test-queries/large-freemap-soe.sql
@@ -1,0 +1,1470 @@
+SELECT 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.web_push_sent
+  ) AS g1000, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:45`.ios_push_errored
+  ) AS g1001, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:12`.sms_errored
+  ) AS g1002, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:56`.sms_errored
+  ) AS g1003, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:07`.android_push_sent
+  ) AS g1004, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.web_push_sent
+  ) AS g1005, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:12`.android_push_errored
+  ) AS g1006, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.sms_sent
+  ) AS g1007, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:44`.android_push_sent
+  ) AS g1008, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:00`.sms_errored
+  ) AS g1009, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:00`.web_push_errored
+  ) AS g1010, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:04`.sms_errored
+  ) AS g1011, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:27`.sms_sent
+  ) AS g1012, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:44`.sms_sent
+  ) AS g1013, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:54`.email_sent
+  ) AS g1014, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:53`.android_push_errored
+  ) AS g1015, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:19`.sms_errored
+  ) AS g1016, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:45`.sms_sent
+  ) AS g1017, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:56`.sms_sent
+  ) AS g1018, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:51`.ios_push_sent
+  ) AS g1019, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.android_push_errored
+  ) AS g1020, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:17`.android_push_errored
+  ) AS g1021, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:04`.email_errored
+  ) AS g1022, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.email_sent
+  ) AS g1023, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.web_push_errored
+  ) AS g1024, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:10`.android_push_sent
+  ) AS g1025, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:53`.email_sent
+  ) AS g1026, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.android_push_sent
+  ) AS g1027, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:39`.ios_push_sent
+  ) AS g1028, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:10`.ios_push_sent
+  ) AS g1029, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:55`.ios_push_errored
+  ) AS g1030, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:51`.sms_sent
+  ) AS g1031, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:45`.email_sent
+  ) AS g1032, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:31`.ios_push_errored
+  ) AS g1033, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:18`.sms_errored
+  ) AS g1034, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:53`.android_push_sent
+  ) AS g1035, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.email_sent
+  ) AS g1036, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.android_push_errored
+  ) AS g1037, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:27`.sms_errored
+  ) AS g1038, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:20`.android_push_sent
+  ) AS g1039, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:03`.ios_push_sent
+  ) AS g1040, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.android_push_errored
+  ) AS g1041, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:47`.email_sent
+  ) AS g1042, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:54`.email_errored
+  ) AS g1043, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:41`.ios_push_errored
+  ) AS g1044, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.web_push_sent
+  ) AS g1045, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:29`.android_push_sent
+  ) AS g1046, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:50`.sms_errored
+  ) AS g1047, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:52`.web_push_errored
+  ) AS g1048, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:52`.android_push_errored
+  ) AS g1049, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.ios_push_sent
+  ) AS g1050, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:50`.ios_push_errored
+  ) AS g1051, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.web_push_errored
+  ) AS g1052, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:54`.web_push_errored
+  ) AS g1053, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:25`.ios_push_sent
+  ) AS g1054, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:25`.android_push_sent
+  ) AS g1055, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:34`.sms_errored
+  ) AS g1056, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:53`.android_push_sent
+  ) AS g1057, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.sms_sent
+  ) AS g1058, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.web_push_sent
+  ) AS g1059, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.email_errored
+  ) AS g1060, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:02`.android_push_sent
+  ) AS g1061, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:18`.email_errored
+  ) AS g1062, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:33`.sms_sent
+  ) AS g1063, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:55`.email_errored
+  ) AS g1064, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:52`.web_push_sent
+  ) AS g1065, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:52`.sms_sent
+  ) AS g1066, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:26`.ios_push_sent
+  ) AS g1067, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:18`.android_push_sent
+  ) AS g1068, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:53`.web_push_sent
+  ) AS g1069, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:12`.sms_sent
+  ) AS g1070, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:53`.email_errored
+  ) AS g1071, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:41`.web_push_sent
+  ) AS g1072, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:48`.email_errored
+  ) AS g1073, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:41`.email_errored
+  ) AS g1074, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:56`.ios_push_sent
+  ) AS g1075, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.ios_push_sent
+  ) AS g1076, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:00`.web_push_sent
+  ) AS g1077, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.sms_errored
+  ) AS g1078, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:55`.sms_sent
+  ) AS g1079, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:05`.web_push_errored
+  ) AS g1080, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:31`.android_push_errored
+  ) AS g1081, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.sms_errored
+  ) AS g1082, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:46`.android_push_sent
+  ) AS g1083, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:00`.sms_sent
+  ) AS g1084, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:51`.email_errored
+  ) AS g1085, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.ios_push_errored
+  ) AS g1086, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:27`.web_push_errored
+  ) AS g1087, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:05`.ios_push_sent
+  ) AS g1088, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:34`.android_push_errored
+  ) AS g1089, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.ios_push_errored
+  ) AS g1090, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.sms_errored
+  ) AS g1091, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:46`.email_errored
+  ) AS g1092, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:10`.sms_sent
+  ) AS g1093, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.email_errored
+  ) AS g1094, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.email_errored
+  ) AS g1095, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:56`.email_errored
+  ) AS g1096, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:54`.email_sent
+  ) AS g1097, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:04`.android_push_errored
+  ) AS g1098, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.sms_sent
+  ) AS g1099, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:04`.web_push_errored
+  ) AS g1100, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:43`.android_push_sent
+  ) AS g1101, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:48`.sms_sent
+  ) AS g1102, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:25`.android_push_errored
+  ) AS g1103, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`12:03`.web_push_errored
+  ) AS g1104, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:19`.ios_push_sent
+  ) AS g1105, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:12`.email_sent
+  ) AS g1106, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.sms_sent
+  ) AS g1107, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:52`.web_push_sent
+  ) AS g1108, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:20`.email_errored
+  ) AS g1109, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:52`.email_errored
+  ) AS g1110, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:33`.email_errored
+  ) AS g1111, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.sms_errored
+  ) AS g1112, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:15`.web_push_errored
+  ) AS g1113, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:27`.web_push_errored
+  ) AS g1114, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.web_push_errored
+  ) AS g1115, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:25`.sms_sent
+  ) AS g1116, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:18`.web_push_errored
+  ) AS g1117, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.email_sent
+  ) AS g1118, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`12:03`.android_push_sent
+  ) AS g1119, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.email_errored
+  ) AS g1120, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:03`.web_push_sent
+  ) AS g1121, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:15`.sms_sent
+  ) AS g1122, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:39`.sms_errored
+  ) AS g1123, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:10`.email_errored
+  ) AS g1124, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:43`.web_push_sent
+  ) AS g1125, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:17`.sms_errored
+  ) AS g1126, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:09`.web_push_sent
+  ) AS g1127, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:48`.web_push_errored
+  ) AS g1128, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:56`.email_sent
+  ) AS g1129, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.ios_push_sent
+  ) AS g1130, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:12`.ios_push_errored
+  ) AS g1131, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:53`.web_push_sent
+  ) AS g1132, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:39`.ios_push_errored
+  ) AS g1133, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:04`.web_push_sent
+  ) AS g1134, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:29`.ios_push_errored
+  ) AS g1135, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:32`.web_push_errored
+  ) AS g1136, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:44`.sms_errored
+  ) AS g1137, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:34`.web_push_errored
+  ) AS g1138, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:27`.android_push_sent
+  ) AS g1139, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:19`.web_push_sent
+  ) AS g1140, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:15`.email_errored
+  ) AS g1141, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:52`.ios_push_errored
+  ) AS g1142, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:15`.email_sent
+  ) AS g1143, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:55`.email_sent
+  ) AS g1144, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:26`.web_push_errored
+  ) AS g1145, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:33`.android_push_errored
+  ) AS g1146, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:12`.web_push_sent
+  ) AS g1147, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.ios_push_errored
+  ) AS g1148, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:03`.web_push_errored
+  ) AS g1149, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.web_push_sent
+  ) AS g1150, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:48`.web_push_sent
+  ) AS g1151, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.sms_errored
+  ) AS g1152, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.web_push_errored
+  ) AS g1153, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.email_sent
+  ) AS g1154, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.email_sent
+  ) AS g1155, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:26`.web_push_sent
+  ) AS g1156, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:12`.sms_errored
+  ) AS g1157, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:00`.ios_push_sent
+  ) AS g1158, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:51`.email_errored
+  ) AS g1159, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:55`.web_push_sent
+  ) AS g1160, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.web_push_errored
+  ) AS g1161, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:55`.ios_push_errored
+  ) AS g1162, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:29`.sms_sent
+  ) AS g1163, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:55`.ios_push_errored
+  ) AS g1164, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:41`.email_sent
+  ) AS g1165, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.ios_push_sent
+  ) AS g1166, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:53`.email_errored
+  ) AS g1167, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:44`.ios_push_errored
+  ) AS g1168, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:52`.sms_sent
+  ) AS g1169, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:39`.ios_push_errored
+  ) AS g1170, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:55`.sms_sent
+  ) AS g1171, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:55`.email_sent
+  ) AS g1172, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:55`.android_push_sent
+  ) AS g1173, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.android_push_sent
+  ) AS g1174, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:51`.ios_push_errored
+  ) AS g1175, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.android_push_sent
+  ) AS g1176, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:55`.ios_push_sent
+  ) AS g1177, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:10`.sms_sent
+  ) AS g1178, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:17`.android_push_sent
+  ) AS g591, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:54`.ios_push_errored
+  ) AS g592, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.web_push_sent
+  ) AS g593, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:04`.ios_push_errored
+  ) AS g594, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:48`.ios_push_sent
+  ) AS g595, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:00`.email_errored
+  ) AS g596, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:12`.ios_push_sent
+  ) AS g597, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:09`.sms_sent
+  ) AS g598, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:41`.sms_errored
+  ) AS g599, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:02`.android_push_errored
+  ) AS g600, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:43`.web_push_errored
+  ) AS g601, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:56`.web_push_sent
+  ) AS g602, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:53`.web_push_errored
+  ) AS g603, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:39`.email_errored
+  ) AS g604, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:04`.android_push_errored
+  ) AS g605, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:10`.email_errored
+  ) AS g606, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.ios_push_sent
+  ) AS g607, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:12`.ios_push_errored
+  ) AS g608, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:10`.sms_errored
+  ) AS g609, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:10`.android_push_errored
+  ) AS g610, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:27`.web_push_sent
+  ) AS g611, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:56`.android_push_sent
+  ) AS g612, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:54`.android_push_errored
+  ) AS g613, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:47`.web_push_sent
+  ) AS g614, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:12`.ios_push_sent
+  ) AS g615, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:53`.sms_sent
+  ) AS g616, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.android_push_errored
+  ) AS g617, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.web_push_errored
+  ) AS g618, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:44`.email_errored
+  ) AS g619, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.android_push_errored
+  ) AS g620, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:19`.email_errored
+  ) AS g621, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:05`.email_sent
+  ) AS g622, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.sms_sent
+  ) AS g623, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:07`.sms_errored
+  ) AS g624, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.android_push_errored
+  ) AS g625, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:00`.email_sent
+  ) AS g626, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:45`.android_push_errored
+  ) AS g627, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:50`.ios_push_sent
+  ) AS g628, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:09`.ios_push_errored
+  ) AS g629, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:45`.sms_errored
+  ) AS g630, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.android_push_sent
+  ) AS g631, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.android_push_errored
+  ) AS g632, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.ios_push_errored
+  ) AS g633, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.email_errored
+  ) AS g634, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:39`.email_sent
+  ) AS g635, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:33`.ios_push_sent
+  ) AS g636, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:34`.ios_push_sent
+  ) AS g637, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:26`.sms_sent
+  ) AS g638, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:52`.email_sent
+  ) AS g639, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:27`.web_push_sent
+  ) AS g640, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:53`.sms_sent
+  ) AS g641, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.web_push_sent
+  ) AS g642, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:05`.sms_sent
+  ) AS g643, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.web_push_sent
+  ) AS g644, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.email_sent
+  ) AS g645, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:53`.sms_errored
+  ) AS g646, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:12`.android_push_sent
+  ) AS g647, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:12`.sms_sent
+  ) AS g648, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:54`.ios_push_sent
+  ) AS g649, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:09`.email_sent
+  ) AS g650, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.ios_push_errored
+  ) AS g651, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.sms_errored
+  ) AS g652, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:51`.email_sent
+  ) AS g653, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:34`.sms_sent
+  ) AS g654, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:03`.email_sent
+  ) AS g655, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:12`.web_push_sent
+  ) AS g656, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:48`.android_push_errored
+  ) AS g657, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`12:03`.sms_errored
+  ) AS g658, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.android_push_errored
+  ) AS g659, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:20`.ios_push_errored
+  ) AS g660, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:52`.android_push_errored
+  ) AS g661, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:02`.ios_push_sent
+  ) AS g662, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:15`.android_push_errored
+  ) AS g663, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:27`.email_errored
+  ) AS g664, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:55`.ios_push_sent
+  ) AS g665, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:20`.web_push_errored
+  ) AS g666, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:54`.ios_push_errored
+  ) AS g667, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.sms_errored
+  ) AS g668, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:46`.ios_push_errored
+  ) AS g669, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:51`.android_push_errored
+  ) AS g670, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:53`.web_push_errored
+  ) AS g671, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.android_push_sent
+  ) AS g672, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:27`.email_sent
+  ) AS g673, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:12`.android_push_sent
+  ) AS g674, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.sms_errored
+  ) AS g675, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:09`.android_push_sent
+  ) AS g676, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.ios_push_errored
+  ) AS g677, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:51`.android_push_sent
+  ) AS g678, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:53`.ios_push_errored
+  ) AS g679, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:51`.android_push_sent
+  ) AS g680, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:15`.web_push_sent
+  ) AS g681, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:12`.email_sent
+  ) AS g682, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.android_push_sent
+  ) AS g683, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:55`.sms_errored
+  ) AS g684, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:55`.email_errored
+  ) AS g685, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`12:03`.ios_push_errored
+  ) AS g686, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:19`.web_push_errored
+  ) AS g687, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:10`.ios_push_sent
+  ) AS g688, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:54`.android_push_sent
+  ) AS g689, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:18`.sms_sent
+  ) AS g690, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:26`.sms_errored
+  ) AS g691, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.ios_push_sent
+  ) AS g692, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:04`.sms_sent
+  ) AS g693, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:12`.ios_push_sent
+  ) AS g694, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.web_push_sent
+  ) AS g695, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.email_errored
+  ) AS g696, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:53`.email_sent
+  ) AS g697, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:39`.sms_sent
+  ) AS g698, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:27`.android_push_errored
+  ) AS g699, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.web_push_sent
+  ) AS g700, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:12`.ios_push_errored
+  ) AS g701, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:52`.email_errored
+  ) AS g702, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:07`.ios_push_sent
+  ) AS g703, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:02`.ios_push_errored
+  ) AS g704, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:09`.email_errored
+  ) AS g705, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:32`.web_push_sent
+  ) AS g706, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:07`.web_push_sent
+  ) AS g707, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:12`.web_push_errored
+  ) AS g708, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:29`.email_errored
+  ) AS g709, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.web_push_sent
+  ) AS g710, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:27`.ios_push_sent
+  ) AS g711, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.ios_push_sent
+  ) AS g712, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:07`.email_sent
+  ) AS g713, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:53`.ios_push_sent
+  ) AS g714, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.ios_push_errored
+  ) AS g715, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:33`.sms_errored
+  ) AS g716, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:12`.android_push_errored
+  ) AS g717, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:55`.web_push_errored
+  ) AS g718, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:39`.android_push_errored
+  ) AS g719, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:27`.email_sent
+  ) AS g720, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:44`.android_push_errored
+  ) AS g721, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:04`.sms_sent
+  ) AS g722, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:34`.web_push_sent
+  ) AS g723, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:50`.sms_sent
+  ) AS g724, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.sms_errored
+  ) AS g725, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:18`.ios_push_errored
+  ) AS g726, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:51`.android_push_errored
+  ) AS g727, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:04`.android_push_sent
+  ) AS g728, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:53`.ios_push_sent
+  ) AS g729, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:39`.email_sent
+  ) AS g730, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:12`.email_errored
+  ) AS g731, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:55`.web_push_sent
+  ) AS g732, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:41`.ios_push_sent
+  ) AS g733, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:20`.sms_errored
+  ) AS g734, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:45`.android_push_sent
+  ) AS g735, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:34`.email_errored
+  ) AS g736, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:56`.android_push_errored
+  ) AS g737, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:55`.sms_sent
+  ) AS g738, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:39`.web_push_errored
+  ) AS g739, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:53`.ios_push_errored
+  ) AS g740, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.email_errored
+  ) AS g741, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:00`.android_push_errored
+  ) AS g742, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:51`.ios_push_sent
+  ) AS g743, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:04`.web_push_errored
+  ) AS g744, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.android_push_sent
+  ) AS g745, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.email_errored
+  ) AS g746, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:46`.web_push_errored
+  ) AS g747, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:54`.email_errored
+  ) AS g748, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:27`.android_push_sent
+  ) AS g749, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:20`.ios_push_sent
+  ) AS g750, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.sms_errored
+  ) AS g751, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.sms_sent
+  ) AS g752, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:05`.email_errored
+  ) AS g753, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:34`.email_sent
+  ) AS g754, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:10`.email_sent
+  ) AS g755, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:18`.android_push_errored
+  ) AS g756, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.ios_push_sent
+  ) AS g757, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.web_push_errored
+  ) AS g758, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:17`.sms_sent
+  ) AS g759, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:31`.email_sent
+  ) AS g760, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:52`.ios_push_errored
+  ) AS g761, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:50`.email_sent
+  ) AS g762, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:55`.email_errored
+  ) AS g763, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:53`.web_push_errored
+  ) AS g764, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:25`.sms_errored
+  ) AS g765, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.email_sent
+  ) AS g766, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:03`.sms_errored
+  ) AS g767, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:29`.ios_push_sent
+  ) AS g768, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:50`.email_errored
+  ) AS g769, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:15`.sms_errored
+  ) AS g770, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:39`.ios_push_sent
+  ) AS g771, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:27`.ios_push_errored
+  ) AS g772, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:04`.android_push_sent
+  ) AS g773, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:31`.email_errored
+  ) AS g774, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:18`.email_sent
+  ) AS g775, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:05`.android_push_sent
+  ) AS g776, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:51`.email_sent
+  ) AS g777, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:56`.ios_push_errored
+  ) AS g778, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:10`.ios_push_errored
+  ) AS g779, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:09`.android_push_errored
+  ) AS g780, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:39`.web_push_sent
+  ) AS g781, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:47`.ios_push_sent
+  ) AS g782, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.web_push_errored
+  ) AS g783, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:41`.android_push_errored
+  ) AS g784, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:25`.web_push_errored
+  ) AS g785, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:53`.ios_push_sent
+  ) AS g786, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:07`.sms_sent
+  ) AS g787, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:31`.android_push_sent
+  ) AS g788, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:47`.email_errored
+  ) AS g789, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.sms_errored
+  ) AS g790, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:48`.ios_push_errored
+  ) AS g791, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:33`.web_push_errored
+  ) AS g792, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:03`.android_push_sent
+  ) AS g793, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:54`.sms_sent
+  ) AS g794, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.email_errored
+  ) AS g795, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:26`.android_push_errored
+  ) AS g796, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:51`.web_push_errored
+  ) AS g797, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.android_push_errored
+  ) AS g798, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:55`.web_push_errored
+  ) AS g799, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.ios_push_errored
+  ) AS g800, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:07`.web_push_errored
+  ) AS g801, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:10`.sms_errored
+  ) AS g802, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:12`.android_push_errored
+  ) AS g803, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:54`.android_push_sent
+  ) AS g804, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:50`.web_push_sent
+  ) AS g805, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:04`.sms_errored
+  ) AS g806, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:12`.web_push_errored
+  ) AS g807, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:55`.sms_errored
+  ) AS g808, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:05`.android_push_errored
+  ) AS g809, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:33`.ios_push_errored
+  ) AS g810, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:32`.sms_errored
+  ) AS g811, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.web_push_errored
+  ) AS g812, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:20`.web_push_sent
+  ) AS g813, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:12`.web_push_errored
+  ) AS g814, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:55`.android_push_errored
+  ) AS g815, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:20`.email_sent
+  ) AS g816, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:54`.ios_push_sent
+  ) AS g817, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:29`.web_push_sent
+  ) AS g818, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.ios_push_sent
+  ) AS g819, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.android_push_sent
+  ) AS g820, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:33`.android_push_sent
+  ) AS g821, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:43`.ios_push_errored
+  ) AS g822, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:52`.ios_push_sent
+  ) AS g823, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`12:03`.email_errored
+  ) AS g824, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:04`.ios_push_errored
+  ) AS g825, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:31`.web_push_errored
+  ) AS g826, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:04`.ios_push_sent
+  ) AS g827, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:52`.sms_errored
+  ) AS g828, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.sms_sent
+  ) AS g829, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:54`.android_push_errored
+  ) AS g830, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:53`.email_errored
+  ) AS g831, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.sms_sent
+  ) AS g832, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.sms_sent
+  ) AS g833, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:43`.ios_push_errored
+  ) AS g834, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.web_push_errored
+  ) AS g835, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.ios_push_errored
+  ) AS g836, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:20`.android_push_errored
+  ) AS g837, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.ios_push_sent
+  ) AS g838, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:51`.sms_errored
+  ) AS g839, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:54`.web_push_sent
+  ) AS g840, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:27`.sms_sent
+  ) AS g841, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:12`.android_push_sent
+  ) AS g842, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:39`.email_errored
+  ) AS g843, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.sms_sent
+  ) AS g844, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.android_push_errored
+  ) AS g845, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:33`.email_sent
+  ) AS g846, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:10`.ios_push_errored
+  ) AS g847, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:45`.email_errored
+  ) AS g848, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:27`.android_push_errored
+  ) AS g849, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:41`.android_push_sent
+  ) AS g850, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:12`.web_push_sent
+  ) AS g851, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:46`.web_push_sent
+  ) AS g852, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:10`.email_sent
+  ) AS g853, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.android_push_sent
+  ) AS g854, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:12`.email_sent
+  ) AS g855, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:55`.web_push_sent
+  ) AS g856, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:03`.ios_push_errored
+  ) AS g857, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:15`.ios_push_sent
+  ) AS g858, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.email_sent
+  ) AS g859, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.android_push_sent
+  ) AS g860, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:55`.web_push_errored
+  ) AS g861, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:46`.sms_errored
+  ) AS g862, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:26`.ios_push_errored
+  ) AS g863, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:52`.ios_push_sent
+  ) AS g864, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.email_sent
+  ) AS g865, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:04`.email_sent
+  ) AS g866, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:46`.android_push_errored
+  ) AS g867, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.ios_push_errored
+  ) AS g868, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.android_push_sent
+  ) AS g869, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.email_sent
+  ) AS g870, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:53`.sms_errored
+  ) AS g871, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:53`.android_push_errored
+  ) AS g872, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.ios_push_sent
+  ) AS g873, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:53`.web_push_sent
+  ) AS g874, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:44`.web_push_sent
+  ) AS g875, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:51`.ios_push_errored
+  ) AS g876, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:44`.web_push_errored
+  ) AS g877, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:25`.email_sent
+  ) AS g878, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:43`.android_push_errored
+  ) AS g879, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.email_sent
+  ) AS g880, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:52`.android_push_sent
+  ) AS g881, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.ios_push_errored
+  ) AS g882, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:34`.ios_push_errored
+  ) AS g883, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:54`.sms_errored
+  ) AS g884, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:39`.web_push_errored
+  ) AS g885, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:09`.ios_push_sent
+  ) AS g886, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:44`.email_sent
+  ) AS g887, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:54`.web_push_sent
+  ) AS g888, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:04`.web_push_sent
+  ) AS g889, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:39`.web_push_sent
+  ) AS g890, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:43`.ios_push_sent
+  ) AS g891, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.email_errored
+  ) AS g892, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.web_push_errored
+  ) AS g893, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:00`.android_push_sent
+  ) AS g894, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:51`.web_push_errored
+  ) AS g895, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.android_push_errored
+  ) AS g896, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:12`.sms_errored
+  ) AS g897, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:10`.web_push_sent
+  ) AS g898, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:03`.email_errored
+  ) AS g899, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.sms_sent
+  ) AS g900 
+FROM 
+  `/datasource/4a2adbe3-2aba-4681-8120-ed8ca53f930e/uncompressed/**` AS r590

--- a/impl/src/test/scala/quasar/impl/Sql2CompilerSpec.scala
+++ b/impl/src/test/scala/quasar/impl/Sql2CompilerSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl
+
+import quasar.Variables
+import quasar.common.PhaseResults
+import quasar.concurrent.unsafe._
+import quasar.contrib.scalaz.MonadTell_
+import quasar.sql.Query
+
+import java.lang.{String, Throwable}
+
+import cats.Eval
+import cats.data.EitherT
+import cats.implicits._
+import cats.effect.{Blocker, IO}
+import cats.effect.testing.specs2.CatsIO
+
+import fs2.{io, text}
+
+import matryoshka.data.Fix
+
+import org.specs2.mutable.Specification
+
+import pathy.Path
+
+import shims.applicativeToScalaz
+
+object Sql2CompilerSpec extends Specification with CatsIO {
+  val blocker = Blocker.unsafeCached("sql2-compiler-spec")
+
+  implicit val phaseResultW = MonadTell_.ignore[EitherT[Eval, QuasarError, ?], PhaseResults]
+
+  val compile =
+    Sql2Compiler[Fix, EitherT[Eval, QuasarError, ?]]
+      .local[String](s => SqlQuery(Query(s), Variables.empty, Path.rootDir))
+
+  "compile a query with very large FreeMap without overflowing stack" >> {
+    val queryName = "/test-queries/large-freemap-soe.sql"
+    val queryIS = IO(getClass.getResourceAsStream(queryName))
+
+    val query =
+      io.readInputStream(queryIS, 8192, blocker)
+        .through(text.utf8Decode)
+        .compile
+        .foldMonoid
+        .unsafeRunSync
+
+    compile(query).value.value must not(throwA[Throwable])
+  }
+}

--- a/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
+++ b/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
@@ -20,6 +20,7 @@ import slamdata.Predef._
 
 import quasar.IdStatus, IdStatus.IncludeId
 import quasar.contrib.cats.stateT._
+import quasar.contrib.matryoshka.safeParaM
 import quasar.contrib.scalaz.MonadState_
 import quasar.ejson
 import quasar.ejson.EJson
@@ -48,8 +49,7 @@ import cats.data.{NonEmptyList, StateT}
 
 import matryoshka._
 import matryoshka.data.free._
-import matryoshka.implicits._
-import matryoshka.patterns.ginterpretM
+import matryoshka.patterns.{ginterpretM, CoEnv}
 
 import monocle.macros.Lenses
 
@@ -349,7 +349,8 @@ sealed abstract class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT: ShowT] exte
     val galgM: GAlgebraM[(FreeMapA[A], ?), Eval, MapFunc, P] =
       mf => Eval.always(computeFuncProvenanceƒ[A](mf))
 
-    fm.paraM(ginterpretM(f.andThen(Eval.now(_)), galgM)).value
+    safeParaM[FreeMapA[A], Eval, CoEnv[A, MapFunc, ?], P](fm)(
+      ginterpretM(f.andThen(Eval.now(_)), galgM)).value
   }
 
   private def computeJoin2[F[_]: Monad: MonadPlannerErr: QAuthS](


### PR DESCRIPTION
* Makes `RenderTree`/`RenderTreeT` instances stack-safe
* Adds a version of `paraM` that is stack-safe when the underlying monad is stack-safe.
* Uses the default `Xss` JVM parameter to avoid masking stack-safety issues
* Adds a test compiling a large query that is known to SOE pre-fixes.

[ch12251]
[ch12257]