### PR TITLE
Compiler stack safety redux

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,6 +1,6 @@
 -Xms512m
 -Xmx3g
--Xss4m
+-Xss2m
 -XX:+UseG1GC
 -XX:+UseStringDeduplication
 -XX:ParallelGCThreads=2

--- a/connector/src/main/scala/quasar/connector/evaluate/QScriptEvaluator.scala
+++ b/connector/src/main/scala/quasar/connector/evaluate/QScriptEvaluator.scala
@@ -20,6 +20,7 @@ import quasar.{RenderTree, RenderTreeT}
 import quasar.common.PhaseResultTell
 import quasar.common.phase
 import quasar.contrib.iota._
+import quasar.contrib.matryoshka.safe
 import quasar.fp.idPrism
 import quasar.qscript._
 import quasar.qscript.rewrites.{
@@ -36,7 +37,6 @@ import cats.syntax.functor._
 import iotaz.{CopK, TListK}
 
 import matryoshka.{Hole => _, _}
-import matryoshka.implicits._
 
 /** Provides for evaluating QScript to a result. */
 abstract class QScriptEvaluator[
@@ -88,7 +88,7 @@ abstract class QScriptEvaluator[
 
   private def toEquiJoin(qs: T[QSEd]): T[QSNorm] = {
     val J = ThetaToEquiJoin[T, QSEd, QSNorm]
-    qs.transCata[T[QSNorm]](J.rewrite[J.G](idPrism.reverseGet))
+    safe.transCata(qs)(J.rewrite[J.G](idPrism.reverseGet))
   }
 
   private final implicit def _QSMFunctor: Functor[QSM] = QSMFunctor

--- a/ejson/src/main/scala/quasar/ejson/implicits.scala
+++ b/ejson/src/main/scala/quasar/ejson/implicits.scala
@@ -18,12 +18,12 @@ package quasar.ejson
 
 import slamdata.Predef._
 import quasar.contrib.matryoshka.{project => projectg, _}
+import quasar.contrib.matryoshka.safe
 import quasar.contrib.iota.{copkTraverse, copkOrder}
 
 import qdata.{QDataDecode, QDataEncode}
 
 import matryoshka._
-import matryoshka.implicits._
 import scalaz.{==>>, Equal, Order}
 import scalaz.std.list._
 import scalaz.syntax.equal._
@@ -41,8 +41,8 @@ object implicits {
     Order.order { (x, y) =>
       implicit val ordExt = Extension.structuralOrder
       OrderR.order[T, EJson](
-        x.transCata[T](EJson.elideMetadata[T]),
-        y.transCata[T](EJson.elideMetadata[T]))
+        safe.transCata(x)(EJson.elideMetadata[T]),
+        safe.transCata(y)(EJson.elideMetadata[T]))
     }
 
   implicit def ejsonQDataDecode[J](implicit T: Recursive.Aux[J, EJson]): QDataDecode[J] =

--- a/foundation/src/main/scala/quasar/RenderTree.scala
+++ b/foundation/src/main/scala/quasar/RenderTree.scala
@@ -17,14 +17,16 @@
 package quasar
 
 import slamdata.Predef._
+import quasar.contrib.matryoshka.safe
 import quasar.fp._
 
 import matryoshka._
 import matryoshka.data._
-import matryoshka.implicits._
+import matryoshka.patterns.{CoEnv, EnvT}
 import scalaz._, Scalaz._
 import simulacrum.typeclass
 import iotaz.{CopK, TListK}
+import shims.monadToScalaz
 
 @typeclass trait RenderTree[A] {
   def render(a: A): RenderedTree
@@ -69,8 +71,10 @@ object RenderTree extends RenderTreeInstances {
   def print[A: RenderTree](label: String, a: A): Unit =
     println(label + ":\n" + a.render.shows)
 
-  def recursive[T, F[_]](implicit T: Recursive.Aux[T, F], FD: Delay[RenderTree, F], FF: Functor[F]): RenderTree[T] =
-    make(_.cata(FD(RenderTree[RenderedTree]).render))
+  def recursive[T, F[_]](implicit T: Recursive.Aux[T, F], FD: Delay[RenderTree, F], FF: Traverse[F]): RenderTree[T] = {
+    val rt = FD(RenderTree[RenderedTree])
+    make(safe.cata[T, F, RenderedTree](_)(rt.render))
+  }
 }
 
 sealed abstract class RenderTreeInstances extends RenderTreeInstances0 {
@@ -84,15 +88,23 @@ sealed abstract class RenderTreeInstances extends RenderTreeInstances0 {
   implicit def delay[F[_], A: RenderTree](implicit F: Delay[RenderTree, F]): RenderTree[F[A]] =
     F(RenderTree[A])
 
-  @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
-  implicit def free[F[_]: Functor](implicit F: Delay[RenderTree, F]): Delay[RenderTree, Free[F, ?]] =
-    Delay.fromNT(λ[RenderTree ~> (RenderTree ∘ Free[F, ?])#λ](rt =>
-      make(_.resume.fold(F(free[F].apply(rt)).render, rt.render))))
+  implicit def coEnvRenderTree[E, F[_]](implicit rt: RenderTree[E], delay: Delay[RenderTree, F]): Delay[RenderTree, CoEnv[E, F, ?]] = {
+    def inst[A](rtA: RenderTree[A]): RenderTree[CoEnv[E, F, A]] = {
+      val rtF = delay(rtA)
+      make(_.run.fold(rt.render, rtF.render))
+    }
 
-  @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
-  implicit def cofree[F[_]](implicit F: Delay[RenderTree, F]): Delay[RenderTree, Cofree[F, ?]] =
-    Delay.fromNT(λ[RenderTree ~> (RenderTree ∘ Cofree[F, ?])#λ](rt =>
-      make(t => NonTerminal(List("Cofree"), None, List(rt.render(t.head), F(cofree(F)(rt)).render(t.tail))))))
+    Delay.fromNT(λ[RenderTree ~> (RenderTree ∘ CoEnv[E, F, ?])#λ](rta => inst(rta)))
+  }
+
+  implicit def envTRenderTree[E, F[_]](implicit rt: RenderTree[E], delay: Delay[RenderTree, F]): Delay[RenderTree, EnvT[E, F, ?]] = {
+    def inst[A](rtA: RenderTree[A]): RenderTree[EnvT[E, F, A]] = {
+      val rtF = delay(rtA)
+      make(et => NonTerminal(Nil, None, List(rt.render(et.ask), rtF.render(et.lower))))
+    }
+
+    Delay.fromNT(λ[RenderTree ~> (RenderTree ∘ EnvT[E, F, ?])#λ](rta => inst(rta)))
+  }
 
   implicit def these[A: RenderTree, B: RenderTree]: RenderTree[A \&/ B] =
     make {
@@ -107,7 +119,7 @@ sealed abstract class RenderTreeInstances extends RenderTreeInstances0 {
   implicit lazy val unit: RenderTree[Unit] =
     make(_ => Terminal(List("()", "Unit"), None))
 
-  implicit def renderTreeT[T[_[_]], F[_]: Functor](implicit T: RenderTreeT[T], F: Delay[RenderTree, F]): RenderTree[T[F]] =
+  implicit def renderTreeT[T[_[_]], F[_]: Traverse](implicit T: RenderTreeT[T], F: Delay[RenderTree, F]): RenderTree[T[F]] =
     T.renderTree(F)
 
   implicit def copKRenderTree[LL <: TListK](implicit M: RenderTreeKMaterializer[LL]): Delay[RenderTree, CopK[LL, ?]] = M.materialize(offset = 0)
@@ -189,13 +201,23 @@ sealed abstract class RenderTreeInstances0 extends RenderTreeInstances1 {
         NonTerminal("Key" :: "Map" :: Nil, Some(k.shows), RV.render(v) :: Nil)
       }))
 
-  implicit def fix[F[_]: Functor](implicit F: Delay[RenderTree, F]): RenderTree[Fix[F]] =
+  implicit def cofreeRenderTree[F[_]: Traverse, A: RenderTree](implicit F: Delay[RenderTree, F])
+      : RenderTree[Cofree[F, A]] = {
+    val rt = RenderTree.recursive[Cofree[F, A], EnvT[A, F, ?]]
+    RenderTree.make[Cofree[F, A]](cf => rt.render(cf).retype(_ => List("Cofree")))
+  }
+
+  implicit def freeRenderTree[F[_]: Traverse, A: RenderTree](implicit F: Delay[RenderTree, F])
+      : RenderTree[Free[F, A]] =
+    RenderTree.recursive[Free[F, A], CoEnv[A, F, ?]]
+
+  implicit def fix[F[_]: Traverse](implicit F: Delay[RenderTree, F]): RenderTree[Fix[F]] =
     RenderTree.recursive
 
-  implicit def mu[F[_]: Functor](implicit F: Delay[RenderTree, F]): RenderTree[Mu[F]] =
+  implicit def mu[F[_]: Traverse](implicit F: Delay[RenderTree, F]): RenderTree[Mu[F]] =
     RenderTree.recursive
 
-  implicit def nu[F[_]: Functor](implicit F: Delay[RenderTree, F]): RenderTree[Nu[F]] =
+  implicit def nu[F[_]: Traverse](implicit F: Delay[RenderTree, F]): RenderTree[Nu[F]] =
     RenderTree.recursive
 }
 

--- a/foundation/src/main/scala/quasar/RenderTreeT.scala
+++ b/foundation/src/main/scala/quasar/RenderTreeT.scala
@@ -16,9 +16,10 @@
 
 package quasar
 
+import quasar.contrib.matryoshka.safe
+
 import matryoshka._
 import matryoshka.data._
-import matryoshka.implicits._
 import scalaz._
 import simulacrum.typeclass
 
@@ -26,17 +27,20 @@ import simulacrum.typeclass
   * an `F` that refers to `T[... F ...]`.
   */
 @typeclass trait RenderTreeT[T[_[_]]] {
-  def render[F[_]: Functor](t: T[F])(implicit delay: Delay[RenderTree, F])
+  def render[F[_]: Traverse](t: T[F])(implicit delay: Delay[RenderTree, F])
       : RenderedTree
 
-  def renderTree[F[_]: Functor](delay: Delay[RenderTree, F]): RenderTree[T[F]] =
-    RenderTree.make[T[F]](t => render(t)(Functor[F], delay))
+  def renderTree[F[_]: Traverse](delay: Delay[RenderTree, F]): RenderTree[T[F]] =
+    RenderTree.make[T[F]](t => render(t)(Traverse[F], delay))
 }
+
 object RenderTreeT {
   def recursiveT[T[_[_]]: RecursiveT]: RenderTreeT[T] =
     new RenderTreeT[T] {
-      def render[F[_]: Functor](t: T[F])(implicit delay: Delay[RenderTree, F]) =
-        delay(renderTree[F](delay)).render(t.project)
+      def render[F[_]: Traverse](t: T[F])(implicit delay: Delay[RenderTree, F]) = {
+        val rt = delay(RenderTree[RenderedTree])
+        safe.cata[T[F], F, RenderedTree](t)(rt.render)
+      }
     }
 
   implicit val fix: RenderTreeT[Fix] = recursiveT

--- a/foundation/src/main/scala/quasar/contrib/matryoshka/package.scala
+++ b/foundation/src/main/scala/quasar/contrib/matryoshka/package.scala
@@ -43,8 +43,8 @@ package object matryoshka {
   object convertToFree {
     def apply[F[_], A] = new PartiallyApplied[F, A]
     final class PartiallyApplied[F[_], A] {
-      def apply[T](t: T)(implicit T: Recursive.Aux[T, F], F: Functor[F]): Free[F, A] =
-        t.ana[Free[F, A]](x => CoEnv(x.project.right[A]))
+      def apply[T](t: T)(implicit T: Recursive.Aux[T, F], F: Traverse[F]): Free[F, A] =
+        safe.ana(t)(x => CoEnv(x.project.right[A]))
     }
   }
 

--- a/foundation/src/main/scala/quasar/contrib/matryoshka/safe.scala
+++ b/foundation/src/main/scala/quasar/contrib/matryoshka/safe.scala
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.contrib.matryoshka
+
+import cats.Eval
+
+import matryoshka.{
+  ∘,
+  Algebra,
+  AlgebraM,
+  AlgebraicGTransform,
+  Coalgebra,
+  CoalgebraM,
+  Corecursive,
+  ElgotAlgebraM,
+  ElgotCoalgebra,
+  GAlgebra,
+  GAlgebraM,
+  GCoalgebra,
+  Recursive
+}
+
+import scalaz.{\/, Functor, Traverse, Monad}
+import scalaz.std.tuple._
+import scalaz.syntax.functor._
+import scalaz.syntax.id._
+import scalaz.syntax.traverse.{ToFunctorOps => _, _}
+import scalaz.syntax.monad.{ToFunctorOps => _, _}
+
+import shims.monadToScalaz
+
+/** Stack-safe versions of various operations. */
+object safe {
+  /** Stack-safe if `M` is stack-safe. */
+  def hyloM[M[_]: Monad, F[_]: Traverse, A, B](
+      a: A)(
+      f: AlgebraM[M, F, B],
+      g: CoalgebraM[M, F, A])
+      : M[B] =
+    g(a).flatMap(_.traverse(hyloM(_)(f, g))).flatMap(f)
+
+  def hylo[F[_]: Traverse, A, B](
+      a: A)(
+      f: Algebra[F, B],
+      g: Coalgebra[F, A])
+      : B =
+    hyloM[Eval, F, A, B](a)(f.andThen(Eval.now(_)), g.andThen(Eval.now(_))).value
+
+  def ana[T, F[_]: Traverse, A](
+      a: A)(
+      f: Coalgebra[F, A])(
+      implicit T: Corecursive.Aux[T, F])
+      : T =
+    hylo[F, A, T](a)(T.embed(_), f)
+
+  def anaM[M[_]: Monad, T, F[_]: Traverse, A](
+      a: A)(
+      f: CoalgebraM[M, F, A])(
+      implicit T: Corecursive.Aux[T, F])
+      : M[T] =
+    hyloM[M, F, A, T](a)(T.embed(_).pure[M], f)
+
+  def cata[T, F[_]: Traverse, A](
+      t: T)(
+      f: Algebra[F, A])(
+      implicit T: Recursive.Aux[T, F])
+      : A =
+    hylo[F, T, A](t)(f, T.project(_))
+
+  def cataM[M[_]: Monad, T, F[_]: Traverse, A](
+      t: T)(
+      f: AlgebraM[M, F, A])(
+      implicit T: Recursive.Aux[T, F])
+      : M[A] =
+    hyloM[M, F, T, A](t)(f, T.project(_).pure[M])
+
+  def para[T, F[_], A](
+      t: T)(
+      f: GAlgebra[(T, ?), F, A])(
+      implicit T: Recursive.Aux[T, F], F: Traverse[F])
+      : A =
+    hylo[λ[α => F[(T, α)]], T, A](t)(
+      f,
+      T.project(_) ∘ (_.squared))(
+      F.compose[(T, ?)])
+
+  def paraM[M[_], T, F[_], A](
+      t: T)(
+      f: GAlgebraM[(T, ?), M, F, A])(
+      implicit M: Monad[M], T: Recursive.Aux[T, F], F: Traverse[F])
+      : M[A] =
+    hyloM[M, λ[α => F[(T, α)]], T, A](t)(
+      f,
+      T.project(_).map(_.squared).pure[M])(
+      M, F.compose[(T, ?)])
+
+  def apo[T, F[_], A](
+      a: A)(
+      f: GCoalgebra[T \/ ?, F, A])(
+      implicit T: Corecursive.Aux[T, F], F: Traverse[F])
+      : T =
+    hylo[λ[α => F[T \/ α]], A, T](
+      a)(
+      fa => T.embed(fa.map(_.merge)), f)(
+      F.compose[T \/ ?])
+
+  def elgotApo[T, F[_]: Traverse, A](
+      a: A)(
+      f: ElgotCoalgebra[T \/ ?, F, A])(
+      implicit T: Corecursive.Aux[T, F])
+      : T =
+    hylo[λ[α => T \/ F[α]], A, T](a)(
+      _.map(T.embed(_)).merge, f)(
+      Traverse[T \/ ?].compose[F])
+
+  def transCata[T, F[_]: Traverse, U, G[_]: Functor](
+      t: T)(
+      f: F[U] => G[U])(
+      implicit T: Recursive.Aux[T, F], U: Corecursive.Aux[U, G])
+      : U =
+    cata[T, F, U](t)(f andThen (U.embed(_)))
+
+  def transCataM[M[_]: Monad, T, F[_]: Traverse, U, G[_]: Functor](
+      t: T)(
+      f: F[U] => M[G[U]])(
+      implicit T: Recursive.Aux[T, F], U: Corecursive.Aux[U, G])
+      : M[U] =
+    cataM[M, T, F, U](t)(f.andThen(_.map(U.embed(_))))
+
+  def transAna[T, F[_]: Functor, U, G[_]: Traverse](
+      t: T)(
+      f: F[T] => G[T])(
+      implicit T: Recursive.Aux[T, F], U: Corecursive.Aux[U, G])
+      : U =
+    ana[U, G, T](t)(f compose (T.project(_)))
+
+  def transAnaM[M[_]: Monad, T, F[_]: Functor, U, G[_]: Traverse](
+      t: T)(
+      f: F[T] => M[G[T]])(
+      implicit T: Recursive.Aux[T, F], U: Corecursive.Aux[U, G])
+      : M[U] =
+    anaM[M, U, G, T](t)(f compose (T.project(_)))
+
+  def transApoT[T, F[_]: Traverse](
+      t: T)(
+      f: T => T \/ T)(
+      implicit
+      TR: Recursive.Aux[T, F],
+      TC: Corecursive.Aux[T, F])
+      : T =
+    elgotApo(t)(f(_).map(TR.project(_)))
+
+  object coelgotM {
+    def apply[M[_]] = new PartiallyApplied[M]
+    final class PartiallyApplied[M[_]] {
+      def apply[F[_], A, B](
+          a: A)(
+          f: ElgotAlgebraM[(A, ?), M, F, B],
+          g: CoalgebraM[M, F, A])(
+          implicit M: Monad[M], F: Traverse[F])
+          : M[B] =
+        hyloM[M, ((A, ?) ∘ F)#λ, A, B](a)(
+          f, a => g(a) strengthL a)(
+          M, Traverse[(A, ?)] compose F)
+    }
+  }
+
+  def transHylo[T, F[_]: Functor, G[_]: Traverse, U, H[_]: Functor](
+      t: T)(
+      f: G[U] => H[U],
+      g: F[T] => G[T])(
+      implicit T: Recursive.Aux[T, F], U: Corecursive.Aux[U, H])
+      : U =
+    hylo(t)(f.andThen(U.embed(_)), g.compose(T.project(_)))
+
+  def transPara[T, F[_]: Traverse, U, G[_]: Functor](
+      t: T)(
+      f: AlgebraicGTransform[(T, ?), U, F, G])(
+      implicit T: Recursive.Aux[T, F], U: Corecursive.Aux[U, G])
+      : U = {
+
+    implicit val nested: Traverse[λ[α => F[(T, α)]]] =
+      Traverse[F].compose[(T, ?)]
+
+    transHylo[T, F, λ[α => F[(T, α)]], U, G](t)(f, _ ∘ (_.squared))
+  }
+
+  def convert[T, F[_]: Traverse, R](
+      t: T)(
+      implicit T: Recursive.Aux[T, F], R: Corecursive.Aux[R, F])
+      : R =
+    cata[T, F, R](t)(R.embed(_))
+}

--- a/foundation/src/main/scala/quasar/fp/tree/package.scala
+++ b/foundation/src/main/scala/quasar/fp/tree/package.scala
@@ -16,9 +16,11 @@
 
 package quasar.fp
 
+import quasar.contrib.matryoshka.implicits._
+import quasar.contrib.matryoshka.safe
+
 import matryoshka._
 import matryoshka.data._
-import matryoshka.implicits._
 import matryoshka.patterns._
 import scalaz._
 
@@ -38,8 +40,8 @@ package object tree {
     case object _1 extends UnaryArg
   }
   implicit class UnaryOps[F[_]](self: Unary[F]) {
-    def eval[T](arg: T)(implicit T: Corecursive.Aux[T, F], F: Functor[F]): T =
-      self.cata(interpret[F, UnaryArg, T](_.fold(arg), _.embed))
+    def eval[T](arg: T)(implicit T: Corecursive.Aux[T, F], F: Traverse[F]): T =
+      safe.cata(self)(interpret[F, UnaryArg, T](_.fold(arg), _.embed))
   }
 
   /** A tree structure with two kinds of holes. See [[BinaryOps.eval]]. */
@@ -61,9 +63,9 @@ package object tree {
   implicit class BinaryOps[F[_]](self: Binary[F]) {
     def eval[T]
       (arg1: T, arg2: T)
-      (implicit T: Corecursive.Aux[T, F], F: Functor[F])
+      (implicit T: Corecursive.Aux[T, F], F: Traverse[F])
         : T =
-      self.cata(interpret[F, BinaryArg, T](_.fold(arg1, arg2), _.embed))
+      safe.cata(self)(interpret[F, BinaryArg, T](_.fold(arg1, arg2), _.embed))
   }
 
   /** A tree structure with three kinds of holes. See [[TernaryOps.eval]]. */
@@ -88,8 +90,8 @@ package object tree {
   implicit class TernaryOps[F[_]](self: Ternary[F]) {
     def eval[T]
       (arg1: T, arg2: T, arg3: T)
-      (implicit T: Corecursive.Aux[T, F], F: Functor[F])
+      (implicit T: Corecursive.Aux[T, F], F: Traverse[F])
         : T =
-      self.cata(interpret[F, TernaryArg, T](_.fold(arg1, arg2, arg3), _.embed))
+      safe.cata(self)(interpret[F, TernaryArg, T](_.fold(arg1, arg2, arg3), _.embed))
   }
 }

--- a/frontend/src/main/scala/quasar/frontend/logicalplan/JoinDir.scala
+++ b/frontend/src/main/scala/quasar/frontend/logicalplan/JoinDir.scala
@@ -18,10 +18,10 @@ package quasar.frontend.logicalplan
 
 import slamdata.Predef._
 import quasar.common.data.Data
+import quasar.contrib.matryoshka.implicits._
 import quasar.std.StdLib._
 
 import matryoshka._
-import matryoshka.implicits._
 
 sealed abstract class JoinDir(val name: String) {
   import structural.MapProject

--- a/frontend/src/main/scala/quasar/frontend/logicalplan/LogicalPlan.scala
+++ b/frontend/src/main/scala/quasar/frontend/logicalplan/LogicalPlan.scala
@@ -20,6 +20,7 @@ import slamdata.Predef._
 import quasar._, RenderTree.ops._
 import quasar.common.{JoinType, SortDir}
 import quasar.common.data.Data
+import quasar.contrib.matryoshka.implicits._
 import quasar.contrib.pathy.{FPath, refineTypeAbs}
 import quasar.contrib.shapeless._
 import quasar.fp._
@@ -30,7 +31,6 @@ import scala.Symbol
 import scala.Predef.$conforms
 
 import matryoshka._
-import matryoshka.implicits._
 import scalaz._, Scalaz._
 import shapeless.{Nat, Sized}
 import pathy.Path.posixCodec

--- a/frontend/src/main/scala/quasar/std/agg.scala
+++ b/frontend/src/main/scala/quasar/std/agg.scala
@@ -19,11 +19,11 @@ package quasar.std
 import slamdata.Predef._
 import quasar._
 import quasar.common.data.Data
+import quasar.contrib.matryoshka.implicits._
 import quasar.fp.ski._
 import quasar.frontend.logicalplan.{LogicalPlan => LP, _}
 
 import matryoshka._
-import matryoshka.implicits._
 import scalaz._, Scalaz._
 import shapeless.{Data => _, :: => _, _}
 

--- a/frontend/src/main/scala/quasar/std/set.scala
+++ b/frontend/src/main/scala/quasar/std/set.scala
@@ -19,10 +19,10 @@ package quasar.std
 import slamdata.Predef._
 import quasar._
 import quasar.common.data.Data
+import quasar.contrib.matryoshka.implicits._
 import quasar.frontend.logicalplan.{LogicalPlan => LP, _}
 
 import matryoshka._
-import matryoshka.implicits._
 import scalaz._, Scalaz._
 import shapeless.{Data => _, _}
 

--- a/frontend/src/main/scala/quasar/std/string.scala
+++ b/frontend/src/main/scala/quasar/std/string.scala
@@ -19,10 +19,10 @@ package quasar.std
 import slamdata.Predef._
 import quasar._
 import quasar.common.data.Data
+import quasar.contrib.matryoshka.implicits._
 import quasar.frontend.logicalplan.{LogicalPlan => LP, _}
 
 import matryoshka._
-import matryoshka.implicits._
 import scalaz._, Scalaz._
 import shapeless.{Data => _, :: => _, _}
 

--- a/frontend/src/main/scala/quasar/std/structural.scala
+++ b/frontend/src/main/scala/quasar/std/structural.scala
@@ -19,11 +19,11 @@ package quasar.std
 import slamdata.Predef._
 import quasar._
 import quasar.common.data.Data
+import quasar.contrib.matryoshka.implicits._
 import quasar.fp._
 import quasar.frontend.logicalplan.{LogicalPlan => LP, _}
 
 import matryoshka._
-import matryoshka.implicits._
 import scalaz._, Scalaz._
 import shapeless.{Data => _, :: => _, _}
 

--- a/impl/src/test/resources/test-queries/case-variations.sql
+++ b/impl/src/test/resources/test-queries/case-variations.sql
@@ -1,0 +1,23 @@
+select distinct
+  case pop
+    when 0 then "nobody"
+    when 1 then "one"
+    when 2 then "a couple"
+    when 3 then "a few"
+    else "more"
+  end as cardinal,
+  case pop
+    when 1 then 0
+    when 10 then 1
+  end as power,
+  case
+    when pop % 2 = 0 then "even"
+    when pop = 1 or pop = 9 then "odd"
+    else "prime"
+  end as parity,
+  case
+    when pop > 5 then pop - 5
+  end as grade
+  from `zips.data`
+  where pop <= 10
+  order by pop

--- a/impl/src/test/resources/test-queries/customer-orders.sql
+++ b/impl/src/test/resources/test-queries/customer-orders.sql
@@ -1,0 +1,47 @@
+SELECT DISTINCT
+  *
+FROM (
+  SELECT DISTINCT
+    row.PurchaseDate AS PurchaseDate,
+    row.City AS City,
+    row.Name AS Name,
+    [row.Brand...] AS Brand,
+    [row.Type...] AS Type,
+    [row.Size...] AS Size,
+    [row.Quantity...] AS Quantity,
+    [row.Color...] AS Color,
+    [row.UnitPrice...] AS UnitPrice,
+    [row.PricePaid...] AS PricePaid,
+    SUM(row.TotalPaid) AS TotalPaid
+  FROM (
+    SELECT
+      o.order_key AS OrderKey,
+      o.purchase_date AS PurchaseDate,
+      c.first_name AS Name,
+      c.city AS City,
+      c.state AS State,
+      i.clothing_size AS Size,
+      i.clothing_type AS Type,
+      i.clothing_color AS Color,
+      i.price AS UnitPrice,
+      oi.qty AS Quantity,
+      i.price * oi.qty AS PricePaid,
+      i.price * oi.qty AS TotalPaid,
+      i.clothing_brand AS Brand
+    FROM
+      `customers.data` AS c INNER JOIN
+      `orders.data` AS o ON c.customer_key = o.customer_key INNER JOIN
+      `ordered_items.data` AS oi ON oi.order_key = o.order_key INNER JOIN
+      `inventory_items.data` AS i ON i.item_key = oi.item_key
+    WHERE
+      c.state = "OH"
+    ORDER BY UnitPrice ASC) AS row
+  GROUP BY
+    row.PurchaseDate,
+    row.City,
+    row.Name
+  ORDER BY
+    row.PurchaseDate ASC,
+    row.City ASC,
+    row.Name ASC) AS foo
+WHERE true

--- a/impl/src/test/resources/test-queries/demo-games-step1.sql
+++ b/impl/src/test/resources/test-queries/demo-games-step1.sql
@@ -1,0 +1,18 @@
+SELECT
+  A_Name AS Game,
+  B_Released AS ReleaseDate,
+  C_Recommendations AS Reviews,
+  D_Metacritic AS Score,
+  PriceInitial AS Price
+FROM
+  `steamgames.data`
+WHERE
+  (IsAction = "TRUE") AND
+  (A_Name <> "") AND
+  (D_Metacritic >= 0) AND
+  (C_Recommendations >= 0)
+ORDER BY
+  D_Metacritic DESC,
+  PriceInitial DESC,
+  A_Name ASC
+LIMIT 10

--- a/impl/src/test/resources/test-queries/demo-games-step2.sql
+++ b/impl/src/test/resources/test-queries/demo-games-step2.sql
@@ -1,0 +1,18 @@
+SELECT
+  A_Name AS Game,
+  B_Released AS ReleaseDate,
+  C_Recommendations AS Reviews,
+  D_Metacritic AS Score,
+  PriceInitial AS Price
+FROM
+  `steamgames.data`
+WHERE
+  (IsAction = "TRUE") AND
+  (LIKE(UPPER(A_Name), "%" || UPPER("Half-Life") || "%", "\\\\")) AND
+  (D_Metacritic >= 94) AND
+  (C_Recommendations >= 12486)
+ORDER BY
+  D_Metacritic DESC,
+  PriceInitial DESC,
+  A_Name ASC
+LIMIT 10

--- a/impl/src/test/resources/test-queries/large-freemap-soe.sql
+++ b/impl/src/test/resources/test-queries/large-freemap-soe.sql
@@ -1,0 +1,1470 @@
+SELECT 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.web_push_sent
+  ) AS g1000, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:45`.ios_push_errored
+  ) AS g1001, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:12`.sms_errored
+  ) AS g1002, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:56`.sms_errored
+  ) AS g1003, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:07`.android_push_sent
+  ) AS g1004, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.web_push_sent
+  ) AS g1005, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:12`.android_push_errored
+  ) AS g1006, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.sms_sent
+  ) AS g1007, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:44`.android_push_sent
+  ) AS g1008, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:00`.sms_errored
+  ) AS g1009, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:00`.web_push_errored
+  ) AS g1010, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:04`.sms_errored
+  ) AS g1011, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:27`.sms_sent
+  ) AS g1012, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:44`.sms_sent
+  ) AS g1013, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:54`.email_sent
+  ) AS g1014, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:53`.android_push_errored
+  ) AS g1015, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:19`.sms_errored
+  ) AS g1016, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:45`.sms_sent
+  ) AS g1017, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:56`.sms_sent
+  ) AS g1018, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:51`.ios_push_sent
+  ) AS g1019, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.android_push_errored
+  ) AS g1020, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:17`.android_push_errored
+  ) AS g1021, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:04`.email_errored
+  ) AS g1022, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.email_sent
+  ) AS g1023, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.web_push_errored
+  ) AS g1024, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:10`.android_push_sent
+  ) AS g1025, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:53`.email_sent
+  ) AS g1026, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.android_push_sent
+  ) AS g1027, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:39`.ios_push_sent
+  ) AS g1028, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:10`.ios_push_sent
+  ) AS g1029, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:55`.ios_push_errored
+  ) AS g1030, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:51`.sms_sent
+  ) AS g1031, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:45`.email_sent
+  ) AS g1032, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:31`.ios_push_errored
+  ) AS g1033, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:18`.sms_errored
+  ) AS g1034, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:53`.android_push_sent
+  ) AS g1035, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.email_sent
+  ) AS g1036, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.android_push_errored
+  ) AS g1037, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:27`.sms_errored
+  ) AS g1038, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:20`.android_push_sent
+  ) AS g1039, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:03`.ios_push_sent
+  ) AS g1040, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.android_push_errored
+  ) AS g1041, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:47`.email_sent
+  ) AS g1042, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:54`.email_errored
+  ) AS g1043, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:41`.ios_push_errored
+  ) AS g1044, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.web_push_sent
+  ) AS g1045, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:29`.android_push_sent
+  ) AS g1046, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:50`.sms_errored
+  ) AS g1047, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:52`.web_push_errored
+  ) AS g1048, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:52`.android_push_errored
+  ) AS g1049, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.ios_push_sent
+  ) AS g1050, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:50`.ios_push_errored
+  ) AS g1051, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.web_push_errored
+  ) AS g1052, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:54`.web_push_errored
+  ) AS g1053, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:25`.ios_push_sent
+  ) AS g1054, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:25`.android_push_sent
+  ) AS g1055, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:34`.sms_errored
+  ) AS g1056, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:53`.android_push_sent
+  ) AS g1057, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.sms_sent
+  ) AS g1058, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.web_push_sent
+  ) AS g1059, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.email_errored
+  ) AS g1060, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:02`.android_push_sent
+  ) AS g1061, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:18`.email_errored
+  ) AS g1062, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:33`.sms_sent
+  ) AS g1063, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:55`.email_errored
+  ) AS g1064, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:52`.web_push_sent
+  ) AS g1065, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:52`.sms_sent
+  ) AS g1066, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:26`.ios_push_sent
+  ) AS g1067, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:18`.android_push_sent
+  ) AS g1068, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:53`.web_push_sent
+  ) AS g1069, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:12`.sms_sent
+  ) AS g1070, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:53`.email_errored
+  ) AS g1071, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:41`.web_push_sent
+  ) AS g1072, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:48`.email_errored
+  ) AS g1073, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:41`.email_errored
+  ) AS g1074, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:56`.ios_push_sent
+  ) AS g1075, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.ios_push_sent
+  ) AS g1076, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:00`.web_push_sent
+  ) AS g1077, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.sms_errored
+  ) AS g1078, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:55`.sms_sent
+  ) AS g1079, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:05`.web_push_errored
+  ) AS g1080, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:31`.android_push_errored
+  ) AS g1081, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.sms_errored
+  ) AS g1082, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:46`.android_push_sent
+  ) AS g1083, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:00`.sms_sent
+  ) AS g1084, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:51`.email_errored
+  ) AS g1085, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.ios_push_errored
+  ) AS g1086, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:27`.web_push_errored
+  ) AS g1087, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:05`.ios_push_sent
+  ) AS g1088, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:34`.android_push_errored
+  ) AS g1089, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.ios_push_errored
+  ) AS g1090, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.sms_errored
+  ) AS g1091, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:46`.email_errored
+  ) AS g1092, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:10`.sms_sent
+  ) AS g1093, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.email_errored
+  ) AS g1094, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.email_errored
+  ) AS g1095, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:56`.email_errored
+  ) AS g1096, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:54`.email_sent
+  ) AS g1097, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:04`.android_push_errored
+  ) AS g1098, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.sms_sent
+  ) AS g1099, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:04`.web_push_errored
+  ) AS g1100, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:43`.android_push_sent
+  ) AS g1101, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:48`.sms_sent
+  ) AS g1102, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:25`.android_push_errored
+  ) AS g1103, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`12:03`.web_push_errored
+  ) AS g1104, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:19`.ios_push_sent
+  ) AS g1105, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:12`.email_sent
+  ) AS g1106, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.sms_sent
+  ) AS g1107, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:52`.web_push_sent
+  ) AS g1108, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:20`.email_errored
+  ) AS g1109, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:52`.email_errored
+  ) AS g1110, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:33`.email_errored
+  ) AS g1111, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.sms_errored
+  ) AS g1112, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:15`.web_push_errored
+  ) AS g1113, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:27`.web_push_errored
+  ) AS g1114, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.web_push_errored
+  ) AS g1115, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:25`.sms_sent
+  ) AS g1116, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:18`.web_push_errored
+  ) AS g1117, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.email_sent
+  ) AS g1118, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`12:03`.android_push_sent
+  ) AS g1119, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.email_errored
+  ) AS g1120, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:03`.web_push_sent
+  ) AS g1121, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:15`.sms_sent
+  ) AS g1122, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:39`.sms_errored
+  ) AS g1123, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:10`.email_errored
+  ) AS g1124, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:43`.web_push_sent
+  ) AS g1125, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:17`.sms_errored
+  ) AS g1126, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:09`.web_push_sent
+  ) AS g1127, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:48`.web_push_errored
+  ) AS g1128, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:56`.email_sent
+  ) AS g1129, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.ios_push_sent
+  ) AS g1130, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:12`.ios_push_errored
+  ) AS g1131, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:53`.web_push_sent
+  ) AS g1132, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:39`.ios_push_errored
+  ) AS g1133, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:04`.web_push_sent
+  ) AS g1134, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:29`.ios_push_errored
+  ) AS g1135, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:32`.web_push_errored
+  ) AS g1136, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:44`.sms_errored
+  ) AS g1137, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:34`.web_push_errored
+  ) AS g1138, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:27`.android_push_sent
+  ) AS g1139, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:19`.web_push_sent
+  ) AS g1140, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:15`.email_errored
+  ) AS g1141, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:52`.ios_push_errored
+  ) AS g1142, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:15`.email_sent
+  ) AS g1143, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:55`.email_sent
+  ) AS g1144, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:26`.web_push_errored
+  ) AS g1145, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:33`.android_push_errored
+  ) AS g1146, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:12`.web_push_sent
+  ) AS g1147, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.ios_push_errored
+  ) AS g1148, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:03`.web_push_errored
+  ) AS g1149, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.web_push_sent
+  ) AS g1150, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:48`.web_push_sent
+  ) AS g1151, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.sms_errored
+  ) AS g1152, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.web_push_errored
+  ) AS g1153, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.email_sent
+  ) AS g1154, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.email_sent
+  ) AS g1155, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:26`.web_push_sent
+  ) AS g1156, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:12`.sms_errored
+  ) AS g1157, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:00`.ios_push_sent
+  ) AS g1158, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:51`.email_errored
+  ) AS g1159, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:55`.web_push_sent
+  ) AS g1160, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.web_push_errored
+  ) AS g1161, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:55`.ios_push_errored
+  ) AS g1162, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:29`.sms_sent
+  ) AS g1163, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:55`.ios_push_errored
+  ) AS g1164, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:41`.email_sent
+  ) AS g1165, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.ios_push_sent
+  ) AS g1166, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:53`.email_errored
+  ) AS g1167, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:44`.ios_push_errored
+  ) AS g1168, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:52`.sms_sent
+  ) AS g1169, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:39`.ios_push_errored
+  ) AS g1170, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:55`.sms_sent
+  ) AS g1171, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:55`.email_sent
+  ) AS g1172, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:55`.android_push_sent
+  ) AS g1173, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.android_push_sent
+  ) AS g1174, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:51`.ios_push_errored
+  ) AS g1175, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.android_push_sent
+  ) AS g1176, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:55`.ios_push_sent
+  ) AS g1177, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:10`.sms_sent
+  ) AS g1178, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:17`.android_push_sent
+  ) AS g591, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:54`.ios_push_errored
+  ) AS g592, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.web_push_sent
+  ) AS g593, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:04`.ios_push_errored
+  ) AS g594, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:48`.ios_push_sent
+  ) AS g595, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:00`.email_errored
+  ) AS g596, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:12`.ios_push_sent
+  ) AS g597, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:09`.sms_sent
+  ) AS g598, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:41`.sms_errored
+  ) AS g599, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:02`.android_push_errored
+  ) AS g600, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:43`.web_push_errored
+  ) AS g601, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:56`.web_push_sent
+  ) AS g602, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:53`.web_push_errored
+  ) AS g603, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:39`.email_errored
+  ) AS g604, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:04`.android_push_errored
+  ) AS g605, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:10`.email_errored
+  ) AS g606, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.ios_push_sent
+  ) AS g607, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:12`.ios_push_errored
+  ) AS g608, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:10`.sms_errored
+  ) AS g609, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:10`.android_push_errored
+  ) AS g610, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:27`.web_push_sent
+  ) AS g611, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:56`.android_push_sent
+  ) AS g612, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:54`.android_push_errored
+  ) AS g613, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:47`.web_push_sent
+  ) AS g614, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:12`.ios_push_sent
+  ) AS g615, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:53`.sms_sent
+  ) AS g616, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.android_push_errored
+  ) AS g617, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.web_push_errored
+  ) AS g618, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:44`.email_errored
+  ) AS g619, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.android_push_errored
+  ) AS g620, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:19`.email_errored
+  ) AS g621, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:05`.email_sent
+  ) AS g622, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.sms_sent
+  ) AS g623, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:07`.sms_errored
+  ) AS g624, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.android_push_errored
+  ) AS g625, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:00`.email_sent
+  ) AS g626, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:45`.android_push_errored
+  ) AS g627, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:50`.ios_push_sent
+  ) AS g628, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:09`.ios_push_errored
+  ) AS g629, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:45`.sms_errored
+  ) AS g630, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.android_push_sent
+  ) AS g631, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.android_push_errored
+  ) AS g632, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.ios_push_errored
+  ) AS g633, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.email_errored
+  ) AS g634, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:39`.email_sent
+  ) AS g635, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:33`.ios_push_sent
+  ) AS g636, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:34`.ios_push_sent
+  ) AS g637, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:26`.sms_sent
+  ) AS g638, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:52`.email_sent
+  ) AS g639, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:27`.web_push_sent
+  ) AS g640, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:53`.sms_sent
+  ) AS g641, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.web_push_sent
+  ) AS g642, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:05`.sms_sent
+  ) AS g643, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.web_push_sent
+  ) AS g644, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.email_sent
+  ) AS g645, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:53`.sms_errored
+  ) AS g646, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:12`.android_push_sent
+  ) AS g647, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:12`.sms_sent
+  ) AS g648, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:54`.ios_push_sent
+  ) AS g649, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:09`.email_sent
+  ) AS g650, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.ios_push_errored
+  ) AS g651, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.sms_errored
+  ) AS g652, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:51`.email_sent
+  ) AS g653, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:34`.sms_sent
+  ) AS g654, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:03`.email_sent
+  ) AS g655, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:12`.web_push_sent
+  ) AS g656, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:48`.android_push_errored
+  ) AS g657, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`12:03`.sms_errored
+  ) AS g658, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.android_push_errored
+  ) AS g659, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:20`.ios_push_errored
+  ) AS g660, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:52`.android_push_errored
+  ) AS g661, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:02`.ios_push_sent
+  ) AS g662, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:15`.android_push_errored
+  ) AS g663, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:27`.email_errored
+  ) AS g664, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:55`.ios_push_sent
+  ) AS g665, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:20`.web_push_errored
+  ) AS g666, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:54`.ios_push_errored
+  ) AS g667, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.sms_errored
+  ) AS g668, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:46`.ios_push_errored
+  ) AS g669, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:51`.android_push_errored
+  ) AS g670, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:53`.web_push_errored
+  ) AS g671, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.android_push_sent
+  ) AS g672, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:27`.email_sent
+  ) AS g673, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:12`.android_push_sent
+  ) AS g674, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.sms_errored
+  ) AS g675, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:09`.android_push_sent
+  ) AS g676, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.ios_push_errored
+  ) AS g677, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:51`.android_push_sent
+  ) AS g678, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:53`.ios_push_errored
+  ) AS g679, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:51`.android_push_sent
+  ) AS g680, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:15`.web_push_sent
+  ) AS g681, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:12`.email_sent
+  ) AS g682, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.android_push_sent
+  ) AS g683, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:55`.sms_errored
+  ) AS g684, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:55`.email_errored
+  ) AS g685, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`12:03`.ios_push_errored
+  ) AS g686, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:19`.web_push_errored
+  ) AS g687, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:10`.ios_push_sent
+  ) AS g688, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:54`.android_push_sent
+  ) AS g689, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:18`.sms_sent
+  ) AS g690, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:26`.sms_errored
+  ) AS g691, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.ios_push_sent
+  ) AS g692, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:04`.sms_sent
+  ) AS g693, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:12`.ios_push_sent
+  ) AS g694, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.web_push_sent
+  ) AS g695, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.email_errored
+  ) AS g696, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:53`.email_sent
+  ) AS g697, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:39`.sms_sent
+  ) AS g698, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:27`.android_push_errored
+  ) AS g699, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.web_push_sent
+  ) AS g700, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:12`.ios_push_errored
+  ) AS g701, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:52`.email_errored
+  ) AS g702, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:07`.ios_push_sent
+  ) AS g703, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:02`.ios_push_errored
+  ) AS g704, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:09`.email_errored
+  ) AS g705, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:32`.web_push_sent
+  ) AS g706, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:07`.web_push_sent
+  ) AS g707, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:12`.web_push_errored
+  ) AS g708, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:29`.email_errored
+  ) AS g709, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.web_push_sent
+  ) AS g710, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:27`.ios_push_sent
+  ) AS g711, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.ios_push_sent
+  ) AS g712, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:07`.email_sent
+  ) AS g713, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:53`.ios_push_sent
+  ) AS g714, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.ios_push_errored
+  ) AS g715, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:33`.sms_errored
+  ) AS g716, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:12`.android_push_errored
+  ) AS g717, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:55`.web_push_errored
+  ) AS g718, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:39`.android_push_errored
+  ) AS g719, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:27`.email_sent
+  ) AS g720, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:44`.android_push_errored
+  ) AS g721, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:04`.sms_sent
+  ) AS g722, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:34`.web_push_sent
+  ) AS g723, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:50`.sms_sent
+  ) AS g724, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.sms_errored
+  ) AS g725, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:18`.ios_push_errored
+  ) AS g726, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:51`.android_push_errored
+  ) AS g727, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:04`.android_push_sent
+  ) AS g728, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:53`.ios_push_sent
+  ) AS g729, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:39`.email_sent
+  ) AS g730, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:12`.email_errored
+  ) AS g731, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:55`.web_push_sent
+  ) AS g732, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:41`.ios_push_sent
+  ) AS g733, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:20`.sms_errored
+  ) AS g734, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:45`.android_push_sent
+  ) AS g735, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:34`.email_errored
+  ) AS g736, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:56`.android_push_errored
+  ) AS g737, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:55`.sms_sent
+  ) AS g738, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:39`.web_push_errored
+  ) AS g739, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:53`.ios_push_errored
+  ) AS g740, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.email_errored
+  ) AS g741, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:00`.android_push_errored
+  ) AS g742, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:51`.ios_push_sent
+  ) AS g743, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:04`.web_push_errored
+  ) AS g744, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.android_push_sent
+  ) AS g745, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.email_errored
+  ) AS g746, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:46`.web_push_errored
+  ) AS g747, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:54`.email_errored
+  ) AS g748, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:27`.android_push_sent
+  ) AS g749, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:20`.ios_push_sent
+  ) AS g750, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.sms_errored
+  ) AS g751, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.sms_sent
+  ) AS g752, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:05`.email_errored
+  ) AS g753, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:34`.email_sent
+  ) AS g754, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:10`.email_sent
+  ) AS g755, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:18`.android_push_errored
+  ) AS g756, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.ios_push_sent
+  ) AS g757, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.web_push_errored
+  ) AS g758, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:17`.sms_sent
+  ) AS g759, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:31`.email_sent
+  ) AS g760, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:52`.ios_push_errored
+  ) AS g761, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:50`.email_sent
+  ) AS g762, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:55`.email_errored
+  ) AS g763, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:53`.web_push_errored
+  ) AS g764, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:25`.sms_errored
+  ) AS g765, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.email_sent
+  ) AS g766, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:03`.sms_errored
+  ) AS g767, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:29`.ios_push_sent
+  ) AS g768, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:50`.email_errored
+  ) AS g769, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:15`.sms_errored
+  ) AS g770, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:39`.ios_push_sent
+  ) AS g771, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:27`.ios_push_errored
+  ) AS g772, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:04`.android_push_sent
+  ) AS g773, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:31`.email_errored
+  ) AS g774, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:18`.email_sent
+  ) AS g775, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:05`.android_push_sent
+  ) AS g776, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:51`.email_sent
+  ) AS g777, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:56`.ios_push_errored
+  ) AS g778, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:10`.ios_push_errored
+  ) AS g779, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:09`.android_push_errored
+  ) AS g780, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:39`.web_push_sent
+  ) AS g781, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:47`.ios_push_sent
+  ) AS g782, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.web_push_errored
+  ) AS g783, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:41`.android_push_errored
+  ) AS g784, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:25`.web_push_errored
+  ) AS g785, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:53`.ios_push_sent
+  ) AS g786, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:07`.sms_sent
+  ) AS g787, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:31`.android_push_sent
+  ) AS g788, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:47`.email_errored
+  ) AS g789, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.sms_errored
+  ) AS g790, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:48`.ios_push_errored
+  ) AS g791, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:33`.web_push_errored
+  ) AS g792, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:03`.android_push_sent
+  ) AS g793, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:54`.sms_sent
+  ) AS g794, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.email_errored
+  ) AS g795, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:26`.android_push_errored
+  ) AS g796, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:51`.web_push_errored
+  ) AS g797, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:23`.android_push_errored
+  ) AS g798, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:55`.web_push_errored
+  ) AS g799, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.ios_push_errored
+  ) AS g800, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:07`.web_push_errored
+  ) AS g801, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:10`.sms_errored
+  ) AS g802, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:12`.android_push_errored
+  ) AS g803, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:54`.android_push_sent
+  ) AS g804, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:50`.web_push_sent
+  ) AS g805, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:04`.sms_errored
+  ) AS g806, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:12`.web_push_errored
+  ) AS g807, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:55`.sms_errored
+  ) AS g808, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:05`.android_push_errored
+  ) AS g809, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:33`.ios_push_errored
+  ) AS g810, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:32`.sms_errored
+  ) AS g811, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.web_push_errored
+  ) AS g812, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:20`.web_push_sent
+  ) AS g813, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:12`.web_push_errored
+  ) AS g814, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:55`.android_push_errored
+  ) AS g815, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:20`.email_sent
+  ) AS g816, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:54`.ios_push_sent
+  ) AS g817, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:29`.web_push_sent
+  ) AS g818, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.ios_push_sent
+  ) AS g819, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.android_push_sent
+  ) AS g820, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:33`.android_push_sent
+  ) AS g821, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:43`.ios_push_errored
+  ) AS g822, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:52`.ios_push_sent
+  ) AS g823, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`12:03`.email_errored
+  ) AS g824, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:04`.ios_push_errored
+  ) AS g825, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:31`.web_push_errored
+  ) AS g826, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:04`.ios_push_sent
+  ) AS g827, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:52`.sms_errored
+  ) AS g828, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.sms_sent
+  ) AS g829, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:54`.android_push_errored
+  ) AS g830, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:53`.email_errored
+  ) AS g831, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.sms_sent
+  ) AS g832, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.sms_sent
+  ) AS g833, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:43`.ios_push_errored
+  ) AS g834, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.web_push_errored
+  ) AS g835, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.ios_push_errored
+  ) AS g836, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:20`.android_push_errored
+  ) AS g837, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:34`.ios_push_sent
+  ) AS g838, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:51`.sms_errored
+  ) AS g839, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:54`.web_push_sent
+  ) AS g840, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:27`.sms_sent
+  ) AS g841, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:12`.android_push_sent
+  ) AS g842, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:39`.email_errored
+  ) AS g843, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.sms_sent
+  ) AS g844, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.android_push_errored
+  ) AS g845, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:33`.email_sent
+  ) AS g846, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:10`.ios_push_errored
+  ) AS g847, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:45`.email_errored
+  ) AS g848, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:27`.android_push_errored
+  ) AS g849, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:41`.android_push_sent
+  ) AS g850, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:12`.web_push_sent
+  ) AS g851, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:46`.web_push_sent
+  ) AS g852, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:10`.email_sent
+  ) AS g853, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.android_push_sent
+  ) AS g854, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:12`.email_sent
+  ) AS g855, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:55`.web_push_sent
+  ) AS g856, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:03`.ios_push_errored
+  ) AS g857, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:15`.ios_push_sent
+  ) AS g858, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`03:30`.email_sent
+  ) AS g859, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.android_push_sent
+  ) AS g860, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`11:55`.web_push_errored
+  ) AS g861, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:46`.sms_errored
+  ) AS g862, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:26`.ios_push_errored
+  ) AS g863, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:52`.ios_push_sent
+  ) AS g864, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.email_sent
+  ) AS g865, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:04`.email_sent
+  ) AS g866, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:46`.android_push_errored
+  ) AS g867, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:05`.ios_push_errored
+  ) AS g868, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:22`.android_push_sent
+  ) AS g869, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.email_sent
+  ) AS g870, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:53`.sms_errored
+  ) AS g871, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`08:53`.android_push_errored
+  ) AS g872, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:09`.ios_push_sent
+  ) AS g873, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:53`.web_push_sent
+  ) AS g874, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:44`.web_push_sent
+  ) AS g875, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:51`.ios_push_errored
+  ) AS g876, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:44`.web_push_errored
+  ) AS g877, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:25`.email_sent
+  ) AS g878, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:43`.android_push_errored
+  ) AS g879, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`10:01`.email_sent
+  ) AS g880, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:52`.android_push_sent
+  ) AS g881, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:09`.ios_push_errored
+  ) AS g882, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:34`.ios_push_errored
+  ) AS g883, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:54`.sms_errored
+  ) AS g884, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:39`.web_push_errored
+  ) AS g885, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:09`.ios_push_sent
+  ) AS g886, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:44`.email_sent
+  ) AS g887, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`07:54`.web_push_sent
+  ) AS g888, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:04`.web_push_sent
+  ) AS g889, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`02:39`.web_push_sent
+  ) AS g890, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`00:43`.ios_push_sent
+  ) AS g891, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:17`.email_errored
+  ) AS g892, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.web_push_errored
+  ) AS g893, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:00`.android_push_sent
+  ) AS g894, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`06:51`.web_push_errored
+  ) AS g895, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.android_push_errored
+  ) AS g896, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`09:12`.sms_errored
+  ) AS g897, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`04:10`.web_push_sent
+  ) AS g898, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`01:03`.email_errored
+  ) AS g899, 
+  `_sd_ensure_number`(
+    r590.stats.`0b6c541d-d142-4950-8ded-cb1a8545ccb9`.`05:49`.sms_sent
+  ) AS g900 
+FROM 
+  `/datasource/4a2adbe3-2aba-4681-8120-ed8ca53f930e/uncompressed/**` AS r590

--- a/impl/src/test/scala/quasar/RegressionQScriptEvaluator.scala
+++ b/impl/src/test/scala/quasar/RegressionQScriptEvaluator.scala
@@ -19,10 +19,10 @@ package quasar.impl
 import quasar._
 import quasar.common.PhaseResultTell
 import quasar.contrib.iota._
+import quasar.contrib.matryoshka.safe
 import quasar.qscript._
 
 import matryoshka.{Hole => _, _}
-import matryoshka.implicits._
 
 import cats.Monad
 import cats.syntax.applicative._
@@ -33,5 +33,6 @@ final class RegressionQScriptEvaluator[
     extends CountingQScriptEvaluator[T, F] {
 
   def optimize(norm: T[QScriptNormalized[T, ?]]): F[T[QSM]] =
-    norm.transCata[T[QSM]](QSNormToQSM.inject(_)).pure[F]
+    safe.transCata[T[QScriptNormalized[T, ?]], QScriptNormalized[T, ?], T[QSM], QSM](norm)(
+      QSNormToQSM.inject(_)).pure[F]
 }

--- a/impl/src/test/scala/quasar/impl/Sql2CompilerSpec.scala
+++ b/impl/src/test/scala/quasar/impl/Sql2CompilerSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl
+
+import quasar.Variables
+import quasar.common.PhaseResults
+import quasar.concurrent.unsafe._
+import quasar.contrib.scalaz.MonadTell_
+import quasar.sql.Query
+
+import scala.StringContext
+import scala.concurrent.duration._
+import java.lang.{String, Throwable}
+
+import cats.Eval
+import cats.data.EitherT
+import cats.implicits._
+import cats.effect.{Blocker, IO}
+import cats.effect.testing.specs2.CatsIO
+
+import fs2.{io, text}
+
+import matryoshka.data.Fix
+
+import org.specs2.mutable.Specification
+
+import pathy.Path
+
+import shims.applicativeToScalaz
+
+object Sql2CompilerSpec extends Specification with CatsIO {
+
+  addSections
+
+  override val Timeout = 30.seconds
+
+  val blocker = Blocker.unsafeCached("sql2-compiler-spec")
+
+  implicit val phaseResultW = MonadTell_.ignore[EitherT[Eval, QuasarError, ?], PhaseResults]
+
+  val compile =
+    Sql2Compiler[Fix, EitherT[Eval, QuasarError, ?]]
+      .local[String](s => SqlQuery(Query(s), Variables.empty, Path.rootDir))
+
+  def queryResource(fileName: String): IO[String] = {
+    val queryIS = IO(getClass.getResourceAsStream(s"/test-queries/$fileName"))
+
+    io.readInputStream(queryIS, 8192, blocker)
+      .through(text.utf8Decode)
+      .compile
+      .foldMonoid
+  }
+
+  def compiles(queryName: String) =
+    queryResource("case-variations.sql")
+      .map(compile(_))
+      .map(_.value.value must beRight)
+
+  "stack safety" >> {
+    "query with very large FreeMap" >> {
+      val query = queryResource("large-freemap-soe.sql")
+      compile(query.unsafeRunSync).value.value must not(throwA[Throwable])
+    }
+  }
+
+  "hashCode abnormalities" >> {
+    // Compile times for these explode if we don't emit strict `FreeMap`s from `CoalesceUnaryMappable`
+    "case-variations" >> compiles("case-variations.sql")
+    "customer-orders" >> compiles("customer-orders.sql")
+    "demo-games-step1" >> compiles("demo-games-step1.sql")
+    "demo-games-step2" >> compiles("demo-games-step2.sql")
+  }
+}

--- a/impl/src/test/scala/quasar/impl/storage/AntiEntropyStoreSpec.scala
+++ b/impl/src/test/scala/quasar/impl/storage/AntiEntropyStoreSpec.scala
@@ -36,6 +36,9 @@ import scala.concurrent.duration._
 import scala.util.Random
 
 final class AntiEntropyStoreSpec extends IndexedStoreSpec[IO, String, String] {
+
+  sequential
+
   implicit val ec: ExecutionContext = ExecutionContext.global
   implicit val strCodec: Codec[String] = utf8_32
   implicit val timer: Timer[IO] = IO.timer(ec)

--- a/qscript/src/main/scala/quasar/qscript/ExpandMapFunc.scala
+++ b/qscript/src/main/scala/quasar/qscript/ExpandMapFunc.scala
@@ -18,12 +18,12 @@ package quasar.qscript
 
 import slamdata.Predef._
 
+import quasar.contrib.matryoshka.safe
 import quasar.ejson.EJson
 import quasar.qscript.{MapFuncsDerived => D}, MapFuncsCore._
 
 import matryoshka._
 import matryoshka.data._
-import matryoshka.implicits._
 import matryoshka.patterns._
 import scalaz.{Divide => _, _}, Scalaz._
 import simulacrum._
@@ -44,8 +44,8 @@ object ExpandMapFunc extends ExpandMapFuncInstances {
       derived: AlgebraM[(Option ∘ F)#λ, MapFuncDerived[T, ?], A])
       : AlgebraM[F, MapFuncDerived[T, ?], A] = { f =>
     derived(f).getOrElse(
-      Free.roll(mapFuncDerived[T, MapFuncCore[T, ?]].expand(f)).cataM[F, A](
-        interpretM[F, MapFuncCore[T, ?], A, A](scala.Predef.implicitly[Monad[F]].point[A](_), core)))
+      safe.cataM(Free.roll(mapFuncDerived[T, MapFuncCore[T, ?]].expand(f)))(
+        interpretM[F, MapFuncCore[T, ?], A, A](_.point[F], core)))
   }
 }
 

--- a/qscript/src/main/scala/quasar/qscript/MapFuncCore.scala
+++ b/qscript/src/main/scala/quasar/qscript/MapFuncCore.scala
@@ -21,6 +21,7 @@ import slamdata.Predef._
 import quasar._
 import quasar.RenderTree.ops._
 import quasar.contrib.matryoshka._
+import quasar.contrib.matryoshka.safe
 import quasar.contrib.matryoshka.implicits._
 import quasar.ejson._
 import quasar.ejson.implicits._
@@ -32,7 +33,6 @@ import quasar.time.TemporalPart
 import cats.Eval
 import matryoshka._
 import matryoshka.data._
-import matryoshka.implicits._
 import matryoshka.patterns._
 import monocle.macros.Lenses
 import scalaz._, Scalaz._
@@ -265,7 +265,7 @@ object MapFuncCore {
   }
 
   def normalize[T[_[_]]: BirecursiveT: EqualT, A: Equal]
-      : CoMapFuncR[T, A] => CoMapFuncR[T, A] =
+      : CoEnv[A, MapFunc[T, ?], FreeMapA[T, A]] => CoEnv[A, MapFunc[T, ?], FreeMapA[T, A]] =
     repeatedly(rewrite[T, A])
 
   def normalized[T[_[_]]: BirecursiveT: EqualT, A: Equal: Show](
@@ -273,7 +273,7 @@ object MapFuncCore {
       : FreeMapA[T, A] = {
 
     def norm(fa: FreeMapA[T, A]): Option[FreeMapA[T, A]] = {
-      val next = fa.transCata[Free[MapFunc[T, ?], A]](normalize[T, A])
+      val next = safe.transCata(fa)(normalize[T, A])
       (next =/= fa) option next
     }
 

--- a/qscript/src/main/scala/quasar/qscript/RecFreeS.scala
+++ b/qscript/src/main/scala/quasar/qscript/RecFreeS.scala
@@ -18,12 +18,15 @@ package quasar.qscript
 
 import slamdata.Predef._
 
-import quasar.{RenderTree, NonTerminal}
+import quasar.{RenderTree, RenderedTree, NonTerminal}
+import quasar.contrib.matryoshka.safe
 import quasar.fp.ski.κ
+
+import cats.Eval
+import cats.implicits._
 
 import matryoshka._
 import matryoshka.data._
-import matryoshka.implicits._
 import matryoshka.patterns.{interpretM, interpret, CoEnv}
 import scalaz._, Scalaz._
 
@@ -54,7 +57,7 @@ object RecFreeS {
       case Fix(form, rec) =>
         recInterpretM[M, F, A](susint, fixint).apply(form) >>= (fixint(_)) >>= {
           case (hole, cont) =>
-            rec.cataM[M, A](
+            safe.cataM(rec)(
               interpretM[M, RecFreeS[F, ?], Hole, A](
                 κ(hole.point[M]),
                 recInterpretM[M, F, A](susint, fixint).apply(_))) >>= (cont(_))
@@ -102,18 +105,24 @@ object RecFreeS {
 
   @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
   implicit def recRenderTree[F[_]: Traverse](implicit FR: Delay[RenderTree, F]): Delay[RenderTree, RecFreeS[F, ?]] =
-    Delay.fromNT(λ[RenderTree ~> (RenderTree ∘ RecFreeS[F, ?])#λ](rt =>
-      RenderTree.make {
-        case Leaf(a) => rt.render(a)
-        case Suspend(fa) => FR.apply(rt).render(fa)
-        case Fix(form, body) =>
-          NonTerminal(
-            List("Let"),
-            none,
-            List(
-              recRenderTree[F].apply(rt).render(form),
-              RenderTree.free[RecFreeS[F, ?]].apply(RenderTree[Hole]).render(body)))
-      }))
+    new Delay[RenderTree, RecFreeS[F, ?]] {
+      def apply[A](ra: RenderTree[A]): RenderTree[RecFreeS[F, A]] = {
+        def go(rec: RecFreeS[F, A]): Eval[RenderedTree] =
+          rec match {
+            case Leaf(a) =>
+              Eval.always(ra.render(a))
+
+            case Suspend(fa) =>
+              Eval.always(FR.apply(ra).render(fa))
+
+            case Fix(form, body) =>
+              (go(form), Eval.always(RenderTree[Free[RecFreeS[F, ?], Hole]].render(body)))
+                .mapN((fm, bd) => NonTerminal(List("Let"), None, List(fm, bd)))
+          }
+
+        RenderTree.make(go(_).value)
+      }
+    }
 
   @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
   implicit def show[F[_]: Traverse](implicit S: Delay[Show, F]): Delay[Show, RecFreeS[F, ?]] =
@@ -128,7 +137,7 @@ object RecFreeS {
           val alg: Algebra[CoEnv[Hole, RecFreeS[F, ?], ?], String] =
             interpret[RecFreeS[F, ?], Hole, String](_.shows, RecFreeS.recInterpret(_.shows, frm => ("SrcHole", c => mkLet(frm, c))))
 
-          mkLet(RecFreeS.show[F].apply(sh).shows(form), body.cata(alg))
+          mkLet(RecFreeS.show[F].apply(sh).shows(form), safe.cata(body)(alg))
         }
       }))
 

--- a/qscript/src/main/scala/quasar/qscript/rewrites/Normalize.scala
+++ b/qscript/src/main/scala/quasar/qscript/rewrites/Normalize.scala
@@ -19,12 +19,12 @@ package quasar.qscript.rewrites
 import slamdata.Predef.{Map => _, _}
 import quasar.RenderTreeT
 import quasar.contrib.iota._
+import quasar.contrib.matryoshka.safe
 import quasar.fp.{coenvBijection, coenvPrism, idPrism, liftCo, PrismNT}
 import quasar.qscript._
 
 import matryoshka.{Hole => _, _}
 import matryoshka.data._
-import matryoshka.implicits._
 import matryoshka.patterns._
 import scalaz.{~>, Functor, NaturalTransformation}
 import scalaz.syntax.either._
@@ -61,5 +61,5 @@ abstract class Normalize[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] {
   }
 
   def branchNorm(branch: FreeQS[T]): FreeQS[T] =
-    branch.transCata[FreeQS[T]](liftCo(normQSCoEnv))
+    safe.transCata(branch)(liftCo(normQSCoEnv))
 }

--- a/qscript/src/main/scala/quasar/qscript/rewrites/NormalizeQScript.scala
+++ b/qscript/src/main/scala/quasar/qscript/rewrites/NormalizeQScript.scala
@@ -18,6 +18,8 @@ package quasar.qscript.rewrites
 
 import slamdata.Predef.{Map => _, _}
 import quasar.RenderTreeT
+import quasar.contrib.matryoshka.implicits._
+import quasar.contrib.matryoshka.safe
 import quasar.contrib.iota._
 import quasar.contrib.scalaz.free._
 import quasar.fp.PrismNT
@@ -25,7 +27,6 @@ import quasar.qscript._
 
 import iotaz.CopK
 import matryoshka.{Hole => _, _}
-import matryoshka.implicits._
 import scalaz.{~>, Functor}
 import scalaz.syntax.monad._
 
@@ -88,6 +89,6 @@ object NormalizeQScript {
       qs: T[QScriptNormalized[T, ?]])
       : T[QScriptNormalized[T, ?]] = {
     val N = new NormalizeQScript[T]
-    qs.transCata[T[QScriptNormalized[T, ?]]](N.normQS)
+    safe.transCata(qs)(N.normQS)
   }
 }

--- a/qscript/src/main/scala/quasar/qscript/rewrites/NormalizeQScriptFreeMap.scala
+++ b/qscript/src/main/scala/quasar/qscript/rewrites/NormalizeQScriptFreeMap.scala
@@ -19,12 +19,12 @@ package quasar.qscript.rewrites
 import slamdata.Predef.{Map => _, _}
 import quasar.RenderTreeT
 import quasar.contrib.iota._
+import quasar.contrib.matryoshka.safe
 import quasar.fp.PrismNT
 import quasar.qscript._
 
 import iotaz.CopK
 import matryoshka.{Hole => _, _}
-import matryoshka.implicits._
 import scalaz.{~>, Functor}
 import scalaz.syntax.functor._
 
@@ -107,6 +107,6 @@ object NormalizeQScriptFreeMap {
       qs: T[QScriptNormalized[T, ?]])
       : T[QScriptNormalized[T, ?]] = {
     val N = new NormalizeQScriptFreeMap[T]
-    qs.transCata[T[QScriptNormalized[T, ?]]](N.normQS)
+    safe.transCata(qs)(N.normQS)
   }
 }

--- a/qscript/src/test/scala/quasar/qscript/MapFuncCoreSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/MapFuncCoreSpec.scala
@@ -26,7 +26,6 @@ import quasar.contrib.matryoshka.implicits._
 import matryoshka.delayShow
 import matryoshka.data.Fix
 import matryoshka.data.free._
-import matryoshka.implicits._
 import scalaz.std.list._
 import scalaz.std.option._
 import scalaz.std.tuple._

--- a/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
+++ b/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
@@ -20,6 +20,7 @@ import slamdata.Predef._
 
 import quasar.IdStatus, IdStatus.IncludeId
 import quasar.contrib.cats.stateT._
+import quasar.contrib.matryoshka.safe
 import quasar.contrib.scalaz.MonadState_
 import quasar.ejson
 import quasar.ejson.EJson
@@ -43,13 +44,11 @@ import quasar.qscript.{
   RightSide3
 }
 
-import cats.Eval
 import cats.data.{NonEmptyList, StateT}
 
 import matryoshka._
 import matryoshka.data.free._
-import matryoshka.implicits._
-import matryoshka.patterns.ginterpretM
+import matryoshka.patterns.CoEnv
 
 import monocle.macros.Lenses
 
@@ -345,12 +344,8 @@ sealed abstract class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT: ShowT] exte
       QAuthS[F].modify(_.addDims(g.root, ds)) as ds
     }
 
-  private def computeFuncProvenance[A](fm: FreeMapA[A])(f: A => P): P = {
-    val galgM: GAlgebraM[(FreeMapA[A], ?), Eval, MapFunc, P] =
-      mf => Eval.always(computeFuncProvenanceƒ[A](mf))
-
-    fm.paraM(ginterpretM(f.andThen(Eval.now(_)), galgM)).value
-  }
+  private def computeFuncProvenance[A](fm: FreeMapA[A])(f: A => P): P =
+    safe.para[FreeMapA[A], CoEnv[A, MapFunc, ?], P](fm)(_.run.fold(f, computeFuncProvenanceƒ[A]))
 
   private def computeJoin2[F[_]: Monad: MonadPlannerErr: QAuthS](
       g: QSUGraph,

--- a/qsu/src/main/scala/quasar/qsu/CoalesceSquashedMappable.scala
+++ b/qsu/src/main/scala/quasar/qsu/CoalesceSquashedMappable.scala
@@ -22,6 +22,8 @@ import quasar.ejson.{EJson, Fixed}
 import quasar.fp._
 import quasar.fp.ski._
 import quasar.contrib.iota._
+import quasar.contrib.matryoshka.implicits._
+import quasar.contrib.matryoshka.safe
 import quasar.contrib.scalaz.free._
 import quasar.qscript.{
   ExtractFunc,
@@ -40,7 +42,6 @@ import cats.data.State
 
 import matryoshka.{Hole => _, _}
 import matryoshka.data._
-import matryoshka.implicits._
 import matryoshka.patterns._
 
 import scalaz.{\/, Foldable, Scalaz}, Scalaz._
@@ -68,7 +69,7 @@ final class CoalesceSquashedMappable[T[_[_]]: BirecursiveT: EqualT] private () e
 
             g.overwriteAtRoot(QSU.Map(
               src.root,
-              MapFuncCore.normalized(outer.linearize.elgotApo[FreeMap](indexedSubst(inner1, ds, sm))).asRec))
+              MapFuncCore.normalized(safe.elgotApo(outer.linearize)(indexedSubst(inner1, ds, sm))).asRec))
 
           case _ =>
             g.overwriteAtRoot(QSU.Map(
@@ -213,7 +214,7 @@ object CoalesceSquashedMappable {
         case other => MapFuncCore.rollMF(other).embed
       }
 
-      val fm1 = fm.cata(interpret(algA, algF))
+      val fm1 = safe.cata(fm)(interpret(algA, algF))
       val keys = Foldable[FreeMapA[T, ?]].foldMap(fm1)(_._1.toSet)
 
       keys.headOption collect {

--- a/qsu/src/main/scala/quasar/qsu/ExtractFreeMap.scala
+++ b/qsu/src/main/scala/quasar/qsu/ExtractFreeMap.scala
@@ -48,7 +48,7 @@ final class ExtractFreeMap[T[_[_]]: BirecursiveT: RenderTreeT: ShowT] private ()
   def apply[F[_]: Monad: NameGenerator: MonadPlannerErr](graph: QSUGraph)
       : F[QSUGraph] = {
     type G[A] = StateT[F, RevIdx, A]
-    graph.rewriteM[G](extract[G]).runA(graph.generateRevIndex)
+    graph.rewriteM[G](extract[G]).runA(graph.reverseIndex)
   }
 
   ////

--- a/qsu/src/main/scala/quasar/qsu/MappableRegion.scala
+++ b/qsu/src/main/scala/quasar/qsu/MappableRegion.scala
@@ -19,6 +19,8 @@ package quasar.qsu
 import slamdata.Predef.{Boolean, Option, None, Set, Symbol}
 import quasar.fp._
 import quasar.contrib.iota._
+import quasar.contrib.matryoshka.implicits._
+import quasar.contrib.matryoshka.safe
 import quasar.fp.ski.κ
 import quasar.qscript.{
   Center,
@@ -37,7 +39,6 @@ import quasar.qscript.{
 
 import matryoshka.{Hole => _, _}
 import matryoshka.data._
-import matryoshka.implicits._
 import matryoshka.patterns._
 import scalaz.{Kleisli, Foldable, Free, Scalaz, Traverse}, Scalaz._
 
@@ -47,8 +48,7 @@ object MappableRegion {
   import QSUGraph.QSUPattern
 
   def apply[T[_[_]]](halt: Symbol => Boolean, g: QSUGraph[T]): FreeMapA[T, QSUGraph[T]] =
-    Free.joinF[MapFunc[T, ?], QSUGraph[T]](
-      g.ana[Free[FreeMapA[T, ?], QSUGraph[T]]](mappableRegionƒ[T](halt, _)))
+    Free.joinF[MapFunc[T, ?], QSUGraph[T]](safe.ana(g)(mappableRegionƒ[T](halt, _)))
 
   def binaryOf[T[_[_]]](left: Symbol, right: Symbol, g: QSUGraph[T]): Option[JoinFunc[T]] =
     funcOf(Kleisli(replaceWith[JoinSide](left, LeftSide)) <+> Kleisli(replaceWith(right, RightSide)), g)

--- a/qsu/src/main/scala/quasar/qsu/MinimizeAutoJoins.scala
+++ b/qsu/src/main/scala/quasar/qsu/MinimizeAutoJoins.scala
@@ -96,7 +96,7 @@ sealed abstract class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT: ShowT: Re
       case (MinimizationState(auth), graph) => AuthenticatedQSU[T, P](graph, auth)
     }
 
-    lifted.runA(agraph.graph.generateRevIndex)
+    lifted.runA(agraph.graph.reverseIndex)
   }
 
   // the Ints are indices into branches

--- a/qsu/src/main/scala/quasar/qsu/PruneSymmetricDimEdits.scala
+++ b/qsu/src/main/scala/quasar/qsu/PruneSymmetricDimEdits.scala
@@ -77,7 +77,7 @@ final class PruneSymmetricDimEdits[T[_[_]]] private () extends QSUTTypes[T] {
         }
     }
 
-    backM.runA(g.generateRevIndex).runA(SMap())
+    backM.runA(g.reverseIndex).runA(SMap())
   }
 
   // does not return Unreferenced()

--- a/qsu/src/main/scala/quasar/qsu/QSUGraph.scala
+++ b/qsu/src/main/scala/quasar/qsu/QSUGraph.scala
@@ -20,6 +20,7 @@ import slamdata.Predef.{Map => SMap, _}
 import quasar.IdStatus
 import quasar.common.effect.NameGenerator
 import quasar.contrib.cats.stateT._
+import quasar.contrib.matryoshka.safe
 import quasar.contrib.iota._
 import quasar.contrib.scalaz._
 import quasar.contrib.scalaz.MonadState_
@@ -34,10 +35,9 @@ import monocle.macros.Lenses
 
 import matryoshka._
 import matryoshka.data._
-import matryoshka.implicits._
 import matryoshka.patterns.EnvT
 
-import scalaz.{\/-, -\/, Cofree, DList, Id, Monad, Monoid, Scalaz, Show}, Scalaz._
+import scalaz.{\/-, -\/, Cofree, DList, Monad, Monoid, Scalaz, Show}, Scalaz._
 
 import shims.{monadToCats, monadToScalaz}
 
@@ -102,10 +102,10 @@ final case class QSUGraph[T[_[_]]](
   }
 
   def foldMapUp[A: Monoid](f: QSUGraph[T] => A): A =
-    foldMapUpM[Id, A](f)
+    foldMapUpM[Eval, A](f.andThen(Eval.now(_))).value
 
   def foldMapDown[A: Monoid](f: QSUGraph[T] => A): A =
-    foldMapDownM[Id, A](f)
+    foldMapDownM[Eval, A](f.andThen(Eval.now(_))).value
 
   def refocus(node: Symbol): QSUGraph[T] =
     copy(root = node)
@@ -288,7 +288,7 @@ final case class QSUGraph[T[_[_]]](
    * function is linear in the number of nodes, so try not to call
    * it too often.
    */
-  def generateRevIndex: QSUGraph.RevIdx[T] =
+  def reverseIndex: QSUGraph.RevIdx[T] =
     vertices map { case (key, value) => value -> key }
 }
 
@@ -368,7 +368,7 @@ object QSUGraph extends QSUGraphInstances {
 
     type F[A] = StateT[State[Long, ?], (NodeNames[T], Renames), A]
 
-    qsu.cataM(fromTreeƒ[T, F]).run((SMap(), SMap())).map {
+    safe.cataM(qsu)(fromTreeƒ[T, F]).run((SMap(), SMap())).map {
       case ((_, s), r) => (s, r)
     }.runA(0).value
   }
@@ -378,7 +378,7 @@ object QSUGraph extends QSUGraphInstances {
     */
   def fromTree[T[_[_]]: RecursiveT](qsu: T[QSU[T, ?]]): QSUGraph[T] =
     fromAnnotatedTree[T](
-      qsu.cata(attributeAlgebra[QSU[T, ?], Option[Symbol]](κ(None))))._2
+      safe.cata(qsu)(attributeAlgebra[QSU[T, ?], Option[Symbol]](κ(None))))._2
 
   private def fromTreeƒ[T[_[_]], F[_]: Monad: NameGenerator: NameState[T, ?[_]]]
       : AlgebraM[F, EnvT[Option[Symbol], QSU[T, ?], ?], QSUGraph[T]] = {
@@ -610,7 +610,7 @@ object QSUGraph extends QSUGraphInstances {
           implicit IC: MapFuncCore[T, ?] :<<: MapFunc[T, ?]): Option[Data] = qgraph match {
 
         case Unary(Unreferenced(), IC(MapFuncsCore.Constant(ejson))) =>
-          Some(ejson.cata(Data.fromEJson))
+          Some(safe.cata(ejson)(Data.fromEJson))
         case _ => None
       }
     }
@@ -620,7 +620,7 @@ object QSUGraph extends QSUGraphInstances {
           implicit IC: MapFuncCore[T, ?] :<<: MapFunc[T, ?]): Option[Data] = qgraph match {
 
         case Map(Unreferenced(), FMFC1(MapFuncsCore.Constant(ejson))) =>
-          Some(ejson.cata(Data.fromEJson))
+          Some(safe.cata(ejson)(Data.fromEJson))
         case _ => None
       }
     }

--- a/qsu/src/main/scala/quasar/qsu/ReifyBuckets.scala
+++ b/qsu/src/main/scala/quasar/qsu/ReifyBuckets.scala
@@ -85,7 +85,7 @@ sealed abstract class ReifyBuckets[T[_[_]]: BirecursiveT: EqualT: ShowT] extends
         }
     }
 
-    bucketsReified.run(aqsu.auth).runA(aqsu.graph.generateRevIndex) map {
+    bucketsReified.run(aqsu.auth).runA(aqsu.graph.reverseIndex) map {
       case (auth, graph) => ApplyProvenance.AuthenticatedQSU(graph, auth)
     }
   }

--- a/qsu/src/main/scala/quasar/qsu/RewriteGroupByArrays.scala
+++ b/qsu/src/main/scala/quasar/qsu/RewriteGroupByArrays.scala
@@ -55,7 +55,7 @@ final class RewriteGroupByArrays[T[_[_]]: BirecursiveT: ShowT] private () extend
         nestedM.map(nested => qgraph.overwriteAtRoot(nested.unfold.map(_.root)) :++ nested)
     }
 
-    back.runA(qgraph.generateRevIndex)
+    back.runA(qgraph.reverseIndex)
   }
 
   object NAryArray {

--- a/qsu/src/main/scala/quasar/qsu/minimizers/MergeCartoix.scala
+++ b/qsu/src/main/scala/quasar/qsu/minimizers/MergeCartoix.scala
@@ -25,7 +25,6 @@ import cats.implicits._
 
 import matryoshka.{Hole => _, _}
 import matryoshka.data.free._
-import matryoshka.implicits._
 import matryoshka.patterns.interpret
 
 import quasar.RenderTreeT
@@ -33,6 +32,7 @@ import quasar.RenderTreeT
 import quasar.common.effect.NameGenerator
 import quasar.contrib.iota._
 import quasar.contrib.matryoshka.implicits._
+import quasar.contrib.matryoshka.safe
 import quasar.contrib.scalaz.free._
 import quasar.contrib.std.errorImpossible
 import quasar.fp.ski.κ2
@@ -289,7 +289,7 @@ sealed abstract class MergeCartoix[T[_[_]]: BirecursiveT: EqualT: RenderTreeT: S
         FreeF(other)
     }
 
-    fm.cata(interpret(fa, ff)).map(_.map(_.reverse))
+    safe.cata(fm)(interpret(fa, ff)).map(_.map(_.reverse))
   }
 
   // Returns an expression where all projections of `Hole` have been

--- a/sql/src/main/scala/quasar/sql/SQLParser.scala
+++ b/sql/src/main/scala/quasar/sql/SQLParser.scala
@@ -18,6 +18,8 @@ package quasar.sql
 
 import slamdata.Predef._
 import quasar.common.{CIName, JoinType}
+import quasar.contrib.matryoshka.implicits._
+import quasar.contrib.matryoshka.safe
 import quasar.fp.ski._
 import quasar.fp._
 
@@ -26,7 +28,6 @@ import scala.util.parsing.combinator.lexical._
 import scala.util.parsing.combinator.syntactical._
 import scala.util.parsing.input.CharArrayReader.EofCh
 import matryoshka._
-import matryoshka.implicits._
 import pathy.Path
 import pathy.Path._
 
@@ -510,5 +511,6 @@ class SQLParser[T[_[_]]: BirecursiveT]
   val parseExpr: String => ParsingError \/ T[Sql] = query =>
     parseWithParser(query, expr).map(normalize)
 
-  private def normalize: T[Sql] => T[Sql] = _.transAna[T[Sql]](repeatedly(normalizeƒ)).makeTables(Nil)
+  private def normalize: T[Sql] => T[Sql] =
+    safe.transAna(_)(repeatedly(normalizeƒ)).makeTables(Nil)
 }


### PR DESCRIPTION
* Introduces `quasar.contrib.matryoshka.safe` containing stack-safe folds and replaces all usages of matryoshka folds with them. We should avoid using any folds from matryoshka going forward (until we come up with a more permanent solution) as they aren't stack-safe in general.
* Makes `RenderTree`/`RenderTreeT` instances stack-safe
* Standardizes on a 2M stack size as the default is platform dependent.
* Adds a test compiling a large query that is known to SOE pre-fixes.

[ch12251]
[ch12257]