### PR TITLE
Separate configuration of push concurrency and total pushes

### DIFF
--- a/.versions.json
+++ b/.versions.json
@@ -1,5 +1,5 @@
 {
   "precog-tectonic": "12.0.9",
   "precog-qdata": "15.0.15",
-  "precog-fs2-job": "1.0.31"
+  "precog-fs2-job": "1.0.31-e084909"
 }

--- a/impl/src/main/scala/quasar/impl/Quasar.scala
+++ b/impl/src/main/scala/quasar/impl/Quasar.scala
@@ -105,6 +105,7 @@ object Quasar extends Logging {
       pushPull: PushmiPullyu[F],
       getAuth: UUID => F[Option[ExternalCredentials[F]]])(
       maxConcurrentPushes: Int,
+      maxOutstandingPushes: Int,
       datasourceModules: List[DatasourceModule],
       destinationModules: List[DestinationModule],
       schedulerBuilders: List[SchedulerBuilder[F]],
@@ -163,6 +164,7 @@ object Quasar extends Logging {
       resultPush <-
         DefaultResultPush[F, UUID, SqlQuery, R](
           maxConcurrentPushes,
+          maxOutstandingPushes,
           destinations.destinationOf(_).map(_.toOption),
           sqlEvaluator,
           resultRender,

--- a/impl/src/main/scala/quasar/impl/push/DefaultResultPush.scala
+++ b/impl/src/main/scala/quasar/impl/push/DefaultResultPush.scala
@@ -625,6 +625,7 @@ private[impl] object DefaultResultPush {
 
   def apply[F[_]: Concurrent: Timer, D: Codec: Order: Show, Q, R](
       maxConcurrentPushes: Int,
+      maxOutstandingPushes: Int,
       lookupDestination: D => F[Option[Destination[F]]],
       evaluator: QueryEvaluator[Resource[F, ?], (Q, Option[Offset]), R],
       render: ResultRender[F, R],
@@ -754,7 +755,8 @@ private[impl] object DefaultResultPush {
 
     val jm =
       JobManager[F, D :: ResourcePath :: HNil, Nothing](
-        jobLimit = maxConcurrentPushes,
+        jobConcurrency = maxConcurrentPushes,
+        jobLimit = maxOutstandingPushes,
         eventsLimit = maxConcurrentPushes)
 
     jm.flatMap(acquire)

--- a/impl/src/test/scala/quasar/impl/push/DefaultResultPushSpec.scala
+++ b/impl/src/test/scala/quasar/impl/push/DefaultResultPushSpec.scala
@@ -343,6 +343,7 @@ object DefaultResultPushSpec extends EffectfulQSpec[IO] with ConditionMatchers {
       resultPush <-
         DefaultResultPush[IO, Int, String, Stream[IO, String]](
           maxConcurrentPushes,
+          maxConcurrentPushes,
           lookupDestination,
           evaluator,
           render,


### PR DESCRIPTION
This allows us to independently decide how many datasets to load concurrently and how many to allow to be enqueued before blocking.