### PR TITLE
Revert http4s to Precog's 0.21.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -289,7 +289,7 @@ lazy val impl = project
       "com.precog"     %% "fs2-job"                  % fs2JobVersion.value,
       "com.precog"     %% "qdata-tectonic"           % qdataVersion.value,
       "com.precog"     %% "tectonic-fs2"             % tectonicVersion.value,
-      "org.http4s"     %% "http4s-async-http-client" % http4sVersion,
+      "org.http4s"     %% "http4s-client"            % http4sVersion,
       "org.http4s"     %% "jawn-fs2"                 % jawnfs2Version,
       "org.slf4s"      %% "slf4s-api"                % slf4sVersion,
       "io.argonaut"    %% "argonaut-jawn"            % argonautVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -289,7 +289,7 @@ lazy val impl = project
       "com.precog"     %% "fs2-job"                  % fs2JobVersion.value,
       "com.precog"     %% "qdata-tectonic"           % qdataVersion.value,
       "com.precog"     %% "tectonic-fs2"             % tectonicVersion.value,
-      "org.http4s"     %% "http4s-client"            % http4sVersion,
+      "com.precog"     %% "http4s-client"            % http4sVersion,
       "org.http4s"     %% "jawn-fs2"                 % jawnfs2Version,
       "org.slf4s"      %% "slf4s-api"                % slf4sVersion,
       "io.argonaut"    %% "argonaut-jawn"            % argonautVersion,
@@ -307,7 +307,7 @@ lazy val impl = project
       // if it is not added here then no HttpClientProvider implementation can be found.
       // See ch11286.
       "com.azure" % "azure-core-http-netty" % "1.5.1",
-      "org.http4s"    %% "http4s-dsl" % http4sVersion  % Test,
+      "com.precog"    %% "http4s-dsl" % http4sVersion  % Test,
       "org.typelevel" %% "discipline-specs2" % disciplineVersion % Test,
       "org.typelevel" %% "kittens" % kittensVersion % Test))
   .evictToLocal("FS2_JOB_PATH", "core")

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -27,5 +27,5 @@ object Versions {
   val iotaVersion         = "0.3.10"
   val drosteVersion       = "0.8.0"
   val h2Version           = "1.4.200"
-  val http4sVersion       = "0.21.8"
+  val http4sVersion       = "0.21.2"
 }


### PR DESCRIPTION
Seems there may be a different issue with AHC client in the latest http4s, reverting back to Precog's version until we can fix upstream.