### PR TITLE
Variant of TimestampedStore that never blocks on modify

### DIFF
--- a/impl/src/test/scala/quasar/impl/storage/AntiEntropyStoreSpec.scala
+++ b/impl/src/test/scala/quasar/impl/storage/AntiEntropyStoreSpec.scala
@@ -62,7 +62,7 @@ final class AntiEntropyStoreSpec extends IndexedStoreSpec[IO, String, String] {
       : Resource[IO, Store] = for {
     atomix <- Atomix.resource[IO](me, seeds.map(_.address))
     storage <- Resource.liftF(IO(new ConcurrentHashMap[String, Timestamped[String]]()))
-    timestamped <- TimestampedStore[IO, String, String](underlying)
+    timestamped <- TimestampedStore.bounded[IO, String, String](underlying, 64)
     cluster = Atomix.cluster[IO](atomix, blocker).contramap(printMessage(_))
     store <- AntiEntropyStore.default[IO, String, String]("default", cluster, timestamped, blocker)
   } yield store


### PR DESCRIPTION
When we want to use `TimestampedStore` in an unclustered server and aren't consuming the `updates` stream, the default bounded queue will eventually fill up and block modifications. To support this case, I've added a new variant of `TimestampedStore`, based on a circular buffer, that will never block modifications.