### PR TITLE
Support external window usage updates

### DIFF
--- a/foundation/src/main/scala/quasar/RateLimiter.scala
+++ b/foundation/src/main/scala/quasar/RateLimiter.scala
@@ -49,7 +49,7 @@ final class RateLimiter[F[_]: Concurrent: Timer, A: Hash] private () {
     }).flatten
   }
 
-  def apply(key: A, max: Int, window: FiniteDuration)
+  def apply(key: A, max: Int, window: FiniteDuration, setUsage: Int => Int)
       : F[RateLimiterEffects[F]] =
     for {
       config <- Concurrent[F] delay {
@@ -64,9 +64,21 @@ final class RateLimiter[F[_]: Concurrent: Timer, A: Hash] private () {
       }
     } yield {
       RateLimiterEffects[F](
-        limit(config, stateRef),
-        backoff(config, stateRef))
+        limit(config, stateRef, setUsage),
+        backoff(config, stateRef),
+        setWindowUsage(stateRef))
     }
+
+  private def setWindowUsage(stateRef: Ref[F, State[F]])(usage: Int)
+      : F[Unit] =
+    for {
+      now <- nowF
+      modified <- stateRef update {
+        case Active(_, _, queue, cancel) => Active(now, usage, queue, cancel)
+        case Done() => Done()
+      }
+    } yield modified
+
 
   /* The backoff function is as a damage control measure, providing a way for
    * information to be communicated back to the rate limiter.
@@ -75,23 +87,15 @@ final class RateLimiter[F[_]: Concurrent: Timer, A: Hash] private () {
    * now. This will trigger any subsequent limits or drains to sleep.
    */
   private def backoff(config: RateLimiterConfig, stateRef: Ref[F, State[F]])
-      : F[Unit] = {
-    val max = config.max
-
-    for {
-      now <- nowF
-      modified <- stateRef update {
-        case Active(_, _, queue, cancel) => Active(now, max, queue, cancel)
-        case Done() => Done()
-      }
-    } yield modified
-  }
+      : F[Unit] =
+    setWindowUsage(stateRef)(config.max)
 
   /* Recursively drains the queue of deferred requests until it is empty.
    *
    * We check which window we're in and determine if we're within the request limit.
    */
-  private def drain(config: RateLimiterConfig, stateRef: Ref[F, State[F]]): F[Unit] = {
+  private def drain(config: RateLimiterConfig, stateRef: Ref[F, State[F]], setUsage: Int => Int)
+      : F[Unit] = {
     val window = config.window
     val max = config.max
 
@@ -108,16 +112,16 @@ final class RateLimiter[F[_]: Concurrent: Timer, A: Hash] private () {
         case Active(current, count, queue, cancel) =>
           if (current + window <= now) { // outside current window, reset the state and loop
             val state = Active(current + window, 0, queue, cancel)
-            val effect = drain(config, stateRef)
+            val effect = drain(config, stateRef, setUsage)
             (state, effect)
           } else if (count < max) { // in current window, and within the limit
             val (elem, remaining) = queue.dequeue
-            val state = Active(current, count + 1, remaining, cancel)
-            val effect = elem.complete(()) >> drain(config, stateRef)
+            val state = Active(current, setUsage(count), remaining, cancel)
+            val effect = elem.complete(()) >> drain(config, stateRef, setUsage)
             (state, effect)
           } else { // in current window, limit exceeded
             val state = Active(current + window, 0, queue, cancel)
-            val effect = Timer[F].sleep((current + window) - now) >> drain(config, stateRef)
+            val effect = Timer[F].sleep((current + window) - now) >> drain(config, stateRef, setUsage)
             (state, effect)
           }
       }
@@ -131,7 +135,8 @@ final class RateLimiter[F[_]: Concurrent: Timer, A: Hash] private () {
    *
    * If the queue is not empty, we enqueue the new request.
    */
-  private def limit(config: RateLimiterConfig, stateRef: Ref[F, State[F]]): F[Unit] = {
+  private def limit(config: RateLimiterConfig, stateRef: Ref[F, State[F]], setUsage: Int => Int)
+      : F[Unit] = {
     val window = config.window
     val max = config.max
 
@@ -144,9 +149,9 @@ final class RateLimiter[F[_]: Concurrent: Timer, A: Hash] private () {
         case Active(current, count, queue, cancel) if queue.isEmpty =>
           if (current + window <= now) { // outside current window, reset the state and loop
             val state = Active[F](current + window, 0, queue, cancel)
-            (state, limit(config, stateRef))
+            (state, limit(config, stateRef, setUsage))
           } else if (count < max) { // in current window, within the limit
-            val state = Active[F](current, count + 1, queue, cancel)
+            val state = Active[F](current, setUsage(count), queue, cancel)
             (state, ().pure[F])
           } else { // in current window, limit exceeded
             val deferred = Deferred.unsafe[F, Unit]
@@ -154,7 +159,7 @@ final class RateLimiter[F[_]: Concurrent: Timer, A: Hash] private () {
             val sleep = Timer[F].sleep((current + window) - now)
             // start draining so we can get the deferred
             val started =
-              Concurrent[F].start(sleep >> drain(config, stateRef)).flatMap(fib =>
+              Concurrent[F].start(sleep >> drain(config, stateRef, setUsage)).flatMap(fib =>
                 stateRef modify[F[Unit]] {
                   case Active(start, count, queue, cancel) =>
                     // we shouldn't need to actually run the old cancel, but we do anyways

--- a/foundation/src/main/scala/quasar/RateLimiterEffects.scala
+++ b/foundation/src/main/scala/quasar/RateLimiterEffects.scala
@@ -16,6 +16,6 @@
 
 package quasar
 
-import slamdata.Predef.Unit
+import slamdata.Predef.{Int, Unit}
 
-final case class RateLimiterEffects[F[_]](limit: F[Unit], backoff: F[Unit])
+final case class RateLimiterEffects[F[_]](limit: F[Unit], backoff: F[Unit], setUsage: Int => F[Unit])

--- a/foundation/src/test/scala/quasar/RateLimiterSpec.scala
+++ b/foundation/src/test/scala/quasar/RateLimiterSpec.scala
@@ -50,7 +50,7 @@ object RateLimiterSpec extends Specification with CatsIO {
           val key = limiting.freshKey
 
           for {
-            effects <- key.flatMap(k => rl(k, 1, 1.seconds))
+            effects <- key.flatMap(k => rl(k, 1, 1.seconds, (_ + 1)))
             stream = Stream.eval_(effects.limit) ++ Stream.emit(1)
             values <- stream.compile.toList
           } yield {
@@ -65,7 +65,7 @@ object RateLimiterSpec extends Specification with CatsIO {
           val key = limiting.freshKey
 
           for {
-            effects <- key.flatMap(k => rl(k, 2, 1.seconds))
+            effects <- key.flatMap(k => rl(k, 2, 1.seconds, (_ + 1)))
             stream =
               Stream.eval_(effects.limit) ++ Stream.emit(1) ++
                 Stream.eval_(effects.limit) ++ Stream.emit(2)
@@ -82,7 +82,7 @@ object RateLimiterSpec extends Specification with CatsIO {
           val key = limiting.freshKey
 
           for {
-            effects <- key.flatMap(k => rl(k, 1, 1.seconds))
+            effects <- key.flatMap(k => rl(k, 1, 1.seconds, (_ + 1)))
             stream =
               Stream.eval_(effects.limit) ++ Stream.emit(1) ++
                 Stream.eval_(effects.limit) ++ Stream.emit(2)
@@ -99,8 +99,8 @@ object RateLimiterSpec extends Specification with CatsIO {
           val key = limiting.freshKey
 
           for {
-            effects1 <- key.flatMap(k => rl(k, 1, 1.seconds))
-            effects2 <- key.flatMap(k => rl(k, 1, 1.seconds))
+            effects1 <- key.flatMap(k => rl(k, 1, 1.seconds, (_ + 1)))
+            effects2 <- key.flatMap(k => rl(k, 1, 1.seconds, (_ + 1)))
 
             stream1 =
               Stream.eval_(effects1.limit) ++ Stream.emit(1) ++
@@ -131,7 +131,7 @@ object RateLimiterSpec extends Specification with CatsIO {
           val key = limiting.freshKey
 
           for {
-            effects <- key.flatMap(k => rl(k, 1, 1.seconds))
+            effects <- key.flatMap(k => rl(k, 1, 1.seconds, (_ + 1)))
             limit = effects.limit
             back <-
                limit >> IO.delay(a += 1) >>
@@ -166,7 +166,7 @@ object RateLimiterSpec extends Specification with CatsIO {
           val key = limiting.freshKey
 
           for {
-            effects <- key.flatMap(k => rl(k, 1, 2.seconds))
+            effects <- key.flatMap(k => rl(k, 1, 2.seconds, (_ + 1)))
             limit = effects.limit
             back <-
               limit >> IO.delay(a += 1) >>
@@ -213,7 +213,7 @@ object RateLimiterSpec extends Specification with CatsIO {
           val key = limiting.freshKey
 
           for {
-            effects <- key.flatMap(k => rl(k, 2, 1.seconds))
+            effects <- key.flatMap(k => rl(k, 2, 1.seconds, (_ + 1)))
             limit = effects.limit
             back <-
               limit >> IO.delay(a += 1) >>
@@ -247,7 +247,7 @@ object RateLimiterSpec extends Specification with CatsIO {
           val key = limiting.freshKey
 
           for {
-            effects <- key.flatMap(k => rl(k, 3, 1.seconds))
+            effects <- key.flatMap(k => rl(k, 3, 1.seconds, (_ + 1)))
             limit = effects.limit
             back <-
               limit >> IO.delay(a += 1) >>
@@ -284,7 +284,7 @@ object RateLimiterSpec extends Specification with CatsIO {
           val key = limiting.freshKey
 
           for {
-            effects <- key.flatMap(k => rl(k, 3, 1.seconds))
+            effects <- key.flatMap(k => rl(k, 3, 1.seconds, (_ + 1)))
             limit = effects.limit
             back <-
               limit >> IO.delay(a += 1) >>
@@ -321,7 +321,7 @@ object RateLimiterSpec extends Specification with CatsIO {
           val key = limiting.freshKey
 
           for {
-            effects <- key.flatMap(k => rl(k, 4, 1.seconds))
+            effects <- key.flatMap(k => rl(k, 4, 1.seconds, (_ + 1)))
             limit = effects.limit
 
             run1 =
@@ -381,7 +381,7 @@ object RateLimiterSpec extends Specification with CatsIO {
           val key = limiting.freshKey
 
           for {
-            effects <- key.flatMap(k => rl(k, 2, 1.seconds))
+            effects <- key.flatMap(k => rl(k, 2, 1.seconds, (_ + 1)))
             limit = effects.limit
 
             run1 =
@@ -458,8 +458,8 @@ object RateLimiterSpec extends Specification with CatsIO {
           for {
             k1 <- key
 
-            _ <- rl(k1, 2, 1.seconds)
-            effects <- rl(k1, 3, 1.seconds)
+            _ <- rl(k1, 2, 1.seconds, (_ + 1))
+            effects <- rl(k1, 3, 1.seconds, (_ + 1))
 
             limit = effects.limit
             back <-
@@ -495,8 +495,8 @@ object RateLimiterSpec extends Specification with CatsIO {
           val key = limiting.freshKey
 
           for {
-            effects1 <- key.flatMap(k => rl(k, 2, 1.seconds))
-            effects2 <- key.flatMap(k => rl(k, 3, 1.seconds))
+            effects1 <- key.flatMap(k => rl(k, 2, 1.seconds, (_ + 1)))
+            effects2 <- key.flatMap(k => rl(k, 3, 1.seconds, (_ + 1)))
 
             limit1 = effects1.limit
             limit2 = effects2.limit
@@ -550,8 +550,8 @@ object RateLimiterSpec extends Specification with CatsIO {
           val key = limiting.freshKey
 
           for {
-            effects1 <- key.flatMap(k => rl(k, 2, 1.seconds))
-            effects2 <- key.flatMap(k => rl(k, 2, 2.seconds))
+            effects1 <- key.flatMap(k => rl(k, 2, 1.seconds, (_ + 1)))
+            effects2 <- key.flatMap(k => rl(k, 2, 2.seconds, (_ + 1)))
 
             limit1 = effects1.limit
             limit2 = effects2.limit
@@ -611,7 +611,7 @@ object RateLimiterSpec extends Specification with CatsIO {
         val key = limiting.freshKey
 
         for {
-          effects <- key.flatMap(k => rl(k, 1, 2.seconds))
+          effects <- key.flatMap(k => rl(k, 1, 2.seconds, (_ + 1)))
 
           limit = effects.limit
           backoff = effects.backoff


### PR DESCRIPTION
This is the first piece required to support [Facebook rate limiting](https://developers.facebook.com/docs/graph-api/overview/rate-limiting/).

The main difference is that Facebook will provide us with a limit rather so we don't need to count the requests/events we make. This will be followed with another PR implementing the Facebook-specific code in the URL datasource.

[ch13331]